### PR TITLE
Fix nav drawer icon focus ring

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -31,6 +31,14 @@ md-top-app-bar [slot="actionIcon"] {
   color: var(--md-sys-color-on-surface, #000000);
 }
 
+#menuButton,
+#closeDrawerButton {
+  --md-focus-ring-width: 0;
+  --md-focus-ring-active-width: 0;
+  --md-focus-ring-color: transparent;
+  outline: none;
+}
+
 #appBarHeadline {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- disable focus ring for the hamburger and close buttons in the navigation drawer

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841c09a2a9c832da9db7ae7897c3221