### PR TITLE
Handle failed song fetch

### DIFF
--- a/assets/js/songs.js
+++ b/assets/js/songs.js
@@ -4,7 +4,8 @@ async function fetchChannelVideos(channelId) {
     const url = `https://piped.video/api/v1/channels/${channelId}/videos`;
     const resp = await fetch(url);
     if (!resp.ok) {
-        throw new Error(`HTTP ${resp.status}`);
+        const errorText = await resp.text();
+        throw new Error(`HTTP error! status: ${resp.status}, message: ${errorText}`);
     }
     const data = await resp.json();
     return (data || []).map(v => ({


### PR DESCRIPTION
## Summary
- fix songs fetch to print clearer errors instead of parsing HTML

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846fe63fd48832da625cb38013ba559