### PR TITLE
Replace alias email and singularize policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mihai's Profile Website
 
-This repository contains the source for a personal profile site built as a small Single Page Application (SPA). The site presents information about Mihai-Cristian Condrea (D4rK) and includes additional pages such as a privacy policy and code of conduct. It is designed as a Progressive Web App using Material Web Components and vanilla JavaScript.
+This repository contains the source for a personal profile site built as a small Single Page Application (SPA). The site presents information about Mihai-Cristian Condrea and includes additional pages such as a privacy policy and code of conduct. It is designed as a Progressive Web App using Material Web Components and vanilla JavaScript.
 
 ## Features
 

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
                             onerror="this.style.backgroundColor='#e0e0e0'; this.src='data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';">
                         <div class="profile-info">
                             <h2>Mihai-Cristian Condrea</h2>
-                            <p>D4rK7355608 / D4rK</p>
+                            <p>Formerly known as D4rK</p>
                         </div>
                     </div>
                     <p class="profile-about">
@@ -211,7 +211,7 @@
                 <a href="https://www.pinterest.com/d4rk7355608/" target="_blank" rel="noopener noreferrer"
                     aria-label="Pinterest Profile" title="Pinterest"> <md-icon-button> <md-icon><i
                                 class="fab fa-pinterest"></i></md-icon> </md-icon-button> </a>
-                <a href="mailto:d4rk7355608@gmail.com" aria-label="Send Email" title="Email"> <md-icon-button>
+                <a href="mailto:contact.mihaicristiancondrea@gmail.com" aria-label="Send Email" title="Email"> <md-icon-button>
                         <md-icon><span class="material-symbols-outlined">email</span></md-icon> </md-icon-button> </a>
                 <a href="https://www.linkedin.com/in/mihai-cristian-condrea/" target="_blank" rel="noopener noreferrer"
                     aria-label="LinkedIn Profile" title="LinkedIn"> <md-icon-button> <md-icon><i

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "profile",
   "version": "1.0.0",
-  "description": "This repository contains the source for a personal profile site built as a small Single Page Application (SPA). The site presents information about Mihai-Cristian Condrea (D4rK) and includes additional pages such as a privacy policy and code of conduct. It is designed as a Progressive Web App using Material Web Components and vanilla JavaScript.",
+  "description": "This repository contains the source for a personal profile site built as a small Single Page Application (SPA). The site presents information about Mihai-Cristian Condrea and includes additional pages such as a privacy policy and code of conduct. It is designed as a Progressive Web App using Material Web Components and vanilla JavaScript.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/pages/more/apps/ads-help-center.html
+++ b/pages/more/apps/ads-help-center.html
@@ -1,34 +1,34 @@
 <div id="adsHelpCenterPageContainer" class="page-section active">
-    <h1>Understanding Advertising in Our Applications</h1>
+    <h1>Understanding Advertising in My Applications</h1>
 
     <img src="assets/images/privacy_and_ads_banner.png"
         alt="Illustration representing advertising and user privacy controls" class="page-banner-image">
 
     <h2 id="introduction">Introduction</h2>
-    <p>Our commitment to transparency, accountability, and respect for user autonomy is central to the way we design and operate our applications. Advertising plays an essential role in ensuring that our products remain freely available while supporting the ongoing development, maintenance, and improvement of our services. This page provides a clear and comprehensive explanation of our advertising practices, the choices available to you, and the safeguards we apply to uphold your privacy and regulatory rights.</p>
+    <p>My commitment to transparency, accountability, and respect for user autonomy is central to the way I design and operate my applications. Advertising plays an essential role in ensuring that my products remain freely available while supporting the ongoing development, maintenance, and improvement of my services. This page provides a clear and comprehensive explanation of my advertising practices, the choices available to you, and the safeguards I apply to uphold your privacy and regulatory rights.</p>
 
     <md-divider></md-divider>
 
-    <h2 id="why-we-use-advertising">Why We Use Advertising</h2>
+    <h2 id="why-I-use-advertising">Why I Use Advertising</h2>
     <h3 id="supporting-accessibility">Supporting Accessibility</h3>
-    <p>Advertising enables us to offer our applications without requiring direct payment. This approach ensures that our tools and services remain accessible to a broad user base, regardless of financial circumstances. Rather than limiting features behind a paywall, advertising allows us to sustain development while keeping the core user experience open and inclusive.</p>
+    <p>Advertising enables me to offer my applications without requiring direct payment. This approach ensures that my tools and services remain accessible to a broad user base, regardless of financial circumstances. Rather than limiting features behind a paywall, advertising allows me to sustain development while keeping the core user experience open and inclusive.</p>
     <h3 id="funding-product-development">Funding Product Development</h3>
-    <p>Revenue generated through advertising allows us to invest in new features, security enhancements, user interface refinements, and long-term performance improvements. This financial model enables continuous innovation and responsiveness to user feedback, fostering a product ecosystem that evolves with your needs.</p>
+    <p>Revenue generated through advertising allows me to invest in new features, security enhancements, user interface refinements, and long-term performance improvements. This financial model enables continuous innovation and responsiveness to user feedback, fostering a product ecosystem that evolves with your needs.</p>
     <h3 id="ensuring-sustainability">Ensuring Sustainability</h3>
-    <p>By responsibly incorporating advertising, we can maintain long-term service availability, offer timely updates, and support the infrastructure that underpins our applications. This model helps balance operational sustainability with the goal of maintaining a respectful, user-first experience.</p>
+    <p>By responsibly incorporating advertising, I can maintain long-term service availability, offer timely updates, and support the infrastructure that underpins my applications. This model helps balance operational sustainability with the goal of maintaining a respectful, user-first experience.</p>
 
     <md-divider></md-divider>
 
     <h2 id="understanding-personalized-advertising">Understanding Personalized Advertising</h2>
     <h3 id="use-of-the-advertising-id">Use of the Advertising ID</h3>
-    <p>Our applications may use the <strong>Google Advertising ID</strong>, a unique, user-resettable identifier provided by the Android operating system. This identifier enables advertisers to deliver relevant ads without accessing personally identifiable information.</p>
+    <p>My applications may use the <strong>Google Advertising ID</strong>, a unique, user-resettable identifier provided by the Android operating system. This identifier enables advertisers to deliver relevant ads without accessing personally identifiable information.</p>
     <p>The Advertising ID is used solely for purposes such as:</p>
     <ul>
         <li>Limiting the number of times an ad is shown</li>
         <li>Ensuring ads are displayed appropriately for your region or language</li>
         <li>Supporting non-intrusive ad personalization (if you have explicitly opted in)</li>
     </ul>
-    <p>We do <strong>not</strong> use the Advertising ID to track users across apps or combine it with any sensitive data. Additionally, our apps respect your system-level privacy preferences; if you choose to reset or restrict the use of your Advertising ID, we honor that choice. This approach allows us to provide a balanced ad experience while maintaining compliance with Google Play requirements and international privacy standards.</p>
+    <p>I do <strong>not</strong> use the Advertising ID to track users across apps or combine it with any sensitive data. Additionally, my apps respect your system-level privacy preferences; if you choose to reset or restrict the use of your Advertising ID, I honor that choice. This approach allows me to provide a balanced ad experience while maintaining compliance with Google Play requirements and international privacy standards.</p>
 
     <h3 id="purpose-and-function">Purpose and Function</h3>
     <p>Personalized advertising refers to the display of advertisements that are more likely to be relevant to your interests, based on non-sensitive signals such as general app usage patterns. This approach seeks to reduce irrelevant content and improve the overall value of the advertising you encounter.</p>
@@ -44,7 +44,7 @@
     <md-divider></md-divider>
 
     <h2 id="your-control-over-advertising">Your Control Over Advertising</h2>
-    <p>We believe that meaningful consent and ongoing control are essential to a trustworthy digital environment. As such, our applications include an <strong>Ad Settings</strong> section within the <strong>Privacy</strong> menu, where you can manage your advertising preferences.</p>
+    <p>I believe that meaningful consent and ongoing control are essential to a trustworthy digital environment. As such, my applications include an <strong>Ad Settings</strong> section within the <strong>Privacy</strong> menu, where you can manage your advertising preferences.</p>
 
     <h3 id="available-options">Available Options</h3>
     <ul>
@@ -57,7 +57,7 @@
     <md-divider></md-divider>
 
     <h2 id="privacy-and-legal-compliance">Privacy and Legal Compliance</h2>
-    <p>We take user privacy seriously and strictly adhere to international and regional data protection regulations, including the <strong>General Data Protection Regulation (GDPR)</strong> and the <strong>ePrivacy Directive</strong>, where applicable.</p>
+    <p>I take user privacy seriously and strictly adhere to international and regional data protection regulations, including the <strong>General Data Protection Regulation (GDPR)</strong> and the <strong>ePrivacy Directive</strong>, where applicable.</p>
 
     <h3 id="consent-requirements">Consent Requirements</h3>
     <p>If you are located in the <strong>European Economic Area (EEA), the United Kingdom, or Switzerland</strong>, you will be presented with a clear and compliant consent form prior to any processing of personal data for advertising purposes. This form will inform you of:</p>
@@ -69,7 +69,7 @@
     <p>You may withdraw your consent at any time from the app’s privacy settings, in full accordance with applicable law.</p>
 
     <h3 id="trusted-partnerships">Trusted Partnerships</h3>
-    <p>We only partner with advertising providers who:</p>
+    <p>I only partner with advertising providers who:</p>
     <ul>
         <li>Comply with recognized industry standards</li>
         <li>Are committed to transparent data practices</li>
@@ -80,27 +80,27 @@
     <md-divider></md-divider>
 
     <h2 id="protection-for-young-users">Protection for Young Users</h2>
-    <p>Where required, we apply special measures to protect users who may be under the age of digital consent. In such cases, we restrict the delivery of personalized ads and limit data collection to the minimum required for the app to function.</p>
-    <p>We remain vigilant in implementing protections that reflect legal obligations and ethical responsibilities, particularly for vulnerable users.</p>
+    <p>Where required, I apply special measures to protect users who may be under the age of digital consent. In such cases, I restrict the delivery of personalized ads and limit data collection to the minimum required for the app to function.</p>
+    <p>I remain vigilant in implementing protections that reflect legal obligations and ethical responsibilities, particularly for vulnerable users.</p>
 
     <md-divider></md-divider>
 
-    <h2 id="our-ongoing-commitment">Our Ongoing Commitment</h2>
-    <p>We continuously evaluate our advertising practices to ensure they reflect evolving legal standards and societal expectations. This includes regular assessments of:</p>
+    <h2 id="my-ongoing-commitment">My Ongoing Commitment</h2>
+    <p>I continuously evaluate my advertising practices to ensure they reflect evolving legal standards and societal expectations. This includes regular assessments of:</p>
     <ul>
         <li>Consent mechanisms</li>
         <li>Partner compliance</li>
         <li>User experience feedback</li>
         <li>Privacy impact</li>
     </ul>
-    <p>We are committed to building products that respect your time, attention, and autonomy. Advertising is integrated only where it adds measurable value to your experience and our long-term mission of product accessibility and excellence.</p>
+    <p>I am committed to building products that respect your time, attention, and autonomy. Advertising is integrated only where it adds measurable value to your experience and my long-term mission of product accessibility and excellence.</p>
 
     <md-divider></md-divider>
 
     <h2 id="contact">Contact</h2>
-    <p>If you have any questions, concerns, or wish to request further information about our advertising practices or privacy commitments, please contact us:</p>
+    <p>If you have any questions, concerns, or wish to request further information about my advertising practices or privacy commitments, please contact me:</p>
     <ul>
-        <li><strong>Email:</strong> <a href="mailto:d4rk7355608@gmail.com">d4rk7355608@gmail.com</a></li>
+        <li><strong>Email:</strong> <a href="mailto:contact.mihaicristiancondrea@gmail.com">contact.mihaicristiancondrea@gmail.com</a></li>
     </ul>
-    <p>We aim to respond in a timely and respectful manner to all inquiries related to your rights and experience as a user.</p>
+    <p>I aim to respond in a timely and respectful manner to all inquiries related to your rights and experience as a user.</p>
 </div>

--- a/pages/more/apps/legal-notices.html
+++ b/pages/more/apps/legal-notices.html
@@ -1,7 +1,7 @@
 <div id="legalNoticesPageContainer" class="page-section active">
     <h1>Legal Notice</h1>
 
-    <p>This application, developed by <strong>Mihai-Cristian Condrea (D4rK)</strong>, includes the following third-party software components:</p>
+    <p>This application, developed by <strong>Mihai-Cristian Condrea</strong>, includes the following third-party software components:</p>
 
     <h2 id="third-party-software">Third-Party Software</h2>
 
@@ -70,7 +70,7 @@
     <md-divider></md-divider>
 
     <h2 id="additional-acknowledgments">Additional Acknowledgments</h2>
-    <p>In addition to the third-party components mentioned above, we would like to express our gratitude to the following individuals and organizations for their contributions:</p>
+    <p>In addition to the third-party components mentioned above, I would like to express my gratitude to the following individuals and organizations for their contributions:</p>
     <ul>
         <li><strong>GitHub:</strong> For providing a platform where developers can share and collaborate on open-source projects.</li>
         <li><strong>Google:</strong> For developing Android Studio and making it freely available to all Android app developers.</li>
@@ -83,10 +83,10 @@
 
     <md-divider></md-divider>
 
-    <h2 id="contact-us">Contact Us</h2>
-    <p>If you have any questions or suggestions about this Legal Notice, do not hesitate to contact Mihai-Cristian Condrea (D4rK) at:
-        <a href="mailto:d4rk7355608@gmail.com">d4rk7355608@gmail.com</a>
+    <h2 id="contact-me">Contact me</h2>
+    <p>If you have any questions or suggestions about this Legal Notice, do not hesitate to contact Mihai-Cristian Condrea at:
+        <a href="mailto:contact.mihaicristiancondrea@gmail.com">contact.mihaicristiancondrea@gmail.com</a>
     </p>
 
-    <p class="last-updated">This Legal Notice was last updated on June 14, 2025. We may update the Legal Notice from time to time, so please review it frequently.</p>
+    <p class="last-updated">This Legal Notice was last updated on June 14, 2025. I may update the Legal Notice from time to time, so please review it frequently.</p>
 </div>

--- a/pages/more/apps/privacy-policy-apps.html
+++ b/pages/more/apps/privacy-policy-apps.html
@@ -1,28 +1,28 @@
 <div id="privacyPolicyAppsPageContainer" class="page-section active">
-    <h1>Privacy Policy for Our Android Applications</h1>
+    <h1>Privacy Policy for My Android Applications</h1>
     <p class="last-updated-text">Last updated: May 31, 2025</p>
 
     <img src="assets/images/app_privacy_banner_shield.png"
          alt="Illustration of a shield representing app data privacy and security"
          class="page-banner-image">
 
-    <p>This Privacy Policy governs the manner in which <strong>Mihai-Cristian Condrea (operating under the alias "D4rK")</strong> ("we," "us," or "our") collects, uses, maintains, and discloses information collected from users (each, a "User") of our Android applications (the "Service" or "Apps"). This privacy policy applies to all applications offered by <strong>Mihai-Cristian Condrea (D4rK)</strong>.</p>
-    <p>By using our Apps, you signify your acceptance of this policy. If you do not agree to this policy, please do not use our Apps. Your continued use of the Apps following the posting of changes to this policy will be deemed your acceptance of those changes.</p>
+    <p>This Privacy Policy governs the manner in which <strong>Mihai-Cristian Condrea</strong> ("I," "me," or "my") collects, uses, maintains, and discloses information collected from users (each, a "User") of my Android applications (the "Service" or "Apps"). This privacy policy applies to all applications offered by <strong>Mihai-Cristian Condrea </strong>.</p>
+    <p>By using my Apps, you signify your acceptance of this policy. If you do not agree to this policy, please do not use my Apps. Your continued use of the Apps following the posting of changes to this policy will be deemed your acceptance of those changes.</p>
 
     <md-divider></md-divider>
 
-    <h2>Information We Collect</h2>
-    <p>Our Apps are designed with your privacy in mind. We collect information primarily to provide and improve the Service, and to ensure its stability and functionality.</p>
+    <h2>Information I Collect</h2>
+    <p>My Apps are designed with your privacy in mind. I collect information primarily to provide and improve the Service, and to ensure its stability and functionality.</p>
 
     <h3>Information You Provide Voluntarily</h3>
-    <p>We do not typically require you to provide personally identifiable information directly to use the core features of our Apps. If any app feature does require such information (e.g., for user accounts or specific services you opt into), it will be clearly indicated at the point of collection, and your explicit consent will be sought.</p>
+    <p>I do not typically require you to provide personally identifiable information directly to use the core features of my Apps. If any app feature does require such information (e.g., for user accounts or specific services you opt into), it will be clearly indicated at the point of collection, and your explicit consent will be sought.</p>
 
     <h3>Information Collected Automatically (Usage Data & Device Information)</h3>
-    <p>When you use our Apps, we and our third-party service providers may automatically collect certain information, including:</p>
+    <p>When you use my Apps, I and my third-party service providers may automatically collect certain information, including:</p>
     <ul>
-        <li><strong>Log Data & Crash Reports:</strong> In case of an error or crash within an App, we collect data and information (through third-party products like Firebase Crashlytics) on your device called Log Data. This Log Data may include information such as your device's Internet Protocol (“IP”) address, device name, operating system version, the configuration of the App when utilizing our Service, the time and date of your use of the Service, error stack traces, and other statistics. This helps us diagnose and fix issues to improve app stability.</li>
-        <li><strong>Analytics Data:</strong> We use Google Analytics for Firebase to understand how our Apps are used. This service collects data such as how often users open the app, what features they use, session duration, device model, operating system version, general geographic location (e.g., country), and other aggregated usage patterns. This data is anonymized or pseudonymized where possible and helps us improve the user experience.</li>
-        <li><strong>Advertising ID:</strong> If you have consented to personalized advertising, our Apps may use your device's Advertising ID (e.g., Google Advertising ID on Android). This identifier is used by advertising networks (like AdMob) to serve ads that may be more relevant to you. You can reset your Advertising ID or opt out of personalized advertising through your device settings.</li>
+        <li><strong>Log Data & Crash Reports:</strong> In case of an error or crash within an App, I collect data and information (through third-party products like Firebase Crashlytics) on your device called Log Data. This Log Data may include information such as your device's Internet Protocol (“IP”) address, device name, operating system version, the configuration of the App when utilizing my Service, the time and date of your use of the Service, error stack traces, and other statistics. This helps me diagnose and fix issues to improve app stability.</li>
+        <li><strong>Analytics Data:</strong> I use Google Analytics for Firebase to understand how my Apps are used. This service collects data such as how often users open the app, what features they use, session duration, device model, operating system version, general geographic location (e.g., country), and other aggregated usage patterns. This data is anonymized or pseudonymized where possible and helps me improve the user experience.</li>
+        <li><strong>Advertising ID:</strong> If you have consented to personalized advertising, my Apps may use your device's Advertising ID (e.g., Google Advertising ID on Android). This identifier is used by advertising networks (like AdMob) to serve ads that may be more relevant to you. You can reset your Advertising ID or opt out of personalized advertising through your device settings.</li>
     </ul>
 
     <img src="assets/images/data_analytics_privacy_banner.png"
@@ -31,20 +31,20 @@
 
     <md-divider></md-divider>
 
-    <h2>How We Use Collected Information</h2>
-    <p><strong>Mihai-Cristian Condrea (D4rK)</strong> may collect and use Users' information for the following purposes:</p>
+    <h2>How I Use Collected Information</h2>
+    <p><strong>Mihai-Cristian Condrea </strong> may collect and use Users' information for the following purposes:</p>
     <ul>
-        <li><strong>To provide and improve our Service:</strong> Information like crash reports and analytics helps us understand issues, fix bugs, and enhance features and usability.</li>
+        <li><strong>To provide and improve my Service:</strong> Information like crash reports and analytics helps me understand issues, fix bugs, and enhance features and usability.</li>
         <li><strong>To personalize user experience (with consent):</strong> If you consent to personalized ads, your Advertising ID may be used to show you more relevant advertisements.</li>
-        <li><strong>To serve advertisements (with consent):</strong> Our Apps may display advertisements via Google AdMob to support the free availability of our services. Your consent for ad-related data processing is managed as described in the "User Consent and Control" section.</li>
-        <li><strong>To ensure app stability and security:</strong> Log data helps us monitor app performance and identify potential security issues.</li>
+        <li><strong>To serve advertisements (with consent):</strong> My Apps may display advertisements via Google AdMob to support the free availability of my services. Your consent for ad-related data processing is managed as described in the "User Consent and Control" section.</li>
+        <li><strong>To ensure app stability and security:</strong> Log data helps me monitor app performance and identify potential security issues.</li>
     </ul>
 
     <md-divider></md-divider>
 
     <h2>Third-Party Service Providers</h2>
-    <p>Our Apps utilize third-party services that may collect information used to identify you or enhance app functionality. We want to inform users of this Service that these third parties may have access to certain information. However, they are obligated not to disclose or use the information for any other purpose than to provide services to us.</p>
-    <p>Links to the privacy policies of third-party service providers used by our Apps:</p>
+    <p>My Apps utilize third-party services that may collect information used to identify you or enhance app functionality. I want to inform users of this Service that these third parties may have access to certain information. However, they are obligated not to disclose or use the information for any other purpose than to provide services to me.</p>
+    <p>Links to the privacy policies of third-party service providers used by my Apps:</p>
     <ul>
         <li><a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Google Play Services</a></li>
         <li><a href="https://support.google.com/admob/answer/6128543" target="_blank" rel="noopener noreferrer">AdMob (Google)</a></li>
@@ -56,8 +56,8 @@
     <md-divider></md-divider>
 
     <h2>User Consent and Control (Google Consent Mode V2)</h2>
-    <p>We respect your privacy choices and are committed to complying with data protection regulations, including the EU User Consent Policy. Our Apps implement Google's Consent Mode V2 to manage how Google services (like Google Analytics for Firebase and AdMob) behave based on your consent status.</p>
-    <p>When you first launch our Apps, or as required by law (particularly if you are in the European Economic Area - EEA, or the UK), you will be presented with a consent banner. This banner allows you to make choices regarding:</p>
+    <p>I respect your privacy choices and are committed to complying with data protection regulations, including the EU User Consent Policy. My Apps implement Google's Consent Mode V2 to manage how Google services (like Google Analytics for Firebase and AdMob) behave based on your consent status.</p>
+    <p>When you first launch my Apps, or as required by law (particularly if you are in the European Economic Area - EEA, or the UK), you will be presented with a consent banner. This banner allows you to make choices regarding:</p>
     <ul>
         <li><strong>Analytics Storage (<code>analytics_storage</code>):</strong> Consent for storing and accessing information for analytics purposes (e.g., usage statistics).</li>
         <li><strong>Ad Storage (<code>ad_storage</code>):</strong> Consent for storing and accessing information related to advertising (e.g., cookies or device identifiers for ads).</li>
@@ -69,7 +69,7 @@
         <li><strong>If you grant consent:</strong> Google services will collect and process data as described for their respective purposes, including personalized advertising if consented to.</li>
         <li><strong>If you deny consent (or do not respond where no default consent is assumed):</strong> Google services will operate in a restricted mode. For example, Google Analytics may collect basic, aggregated data without using identifiers, and AdMob may serve non-personalized ads. Pings sent by Google services will be anonymized and will not use cookies or device identifiers for personalization.</li>
     </ul>
-    <p>You can typically change your consent preferences at any time from within the App's settings menu (e.g., under "Privacy Settings" or "Ad Settings"). We honor your choices, and these are passed to the relevant Google SDKs.</p>
+    <p>You can typically change your consent preferences at any time from within the App's settings menu (e.g., under "Privacy Settings" or "Ad Settings"). I honor your choices, and these are passed to the relevant Google SDKs.</p>
 
     <img src="assets/images/user_control_privacy_banner.png"
          alt="Illustration depicting user control over privacy settings"
@@ -78,30 +78,30 @@
     <md-divider></md-divider>
 
     <h2>Cookies</h2>
-    <p>Our Apps do not use “cookies” explicitly in the traditional web browser sense. However, third-party code and libraries integrated into our Apps (such as those from Google for ads and analytics) may use similar technologies like device identifiers or SDK-specific storage mechanisms that function like cookies to collect information and improve their services. Your consent choices, as managed through Google Consent Mode, will affect how these technologies are used.</p>
+    <p>My Apps do not use “cookies” explicitly in the traditional web browser sense. However, third-party code and libraries integrated into my Apps (such as those from Google for ads and analytics) may use similar technologies like device identifiers or SDK-specific storage mechanisms that function like cookies to collect information and improve their services. Your consent choices, as managed through Google Consent Mode, will affect how these technologies are used.</p>
 
     <md-divider></md-divider>
 
     <h2>Security</h2>
-    <p>We value your trust and strive to use commercially acceptable means of protecting any information processed by our Apps and third-party services. However, remember that no method of transmission over the internet, or method of electronic storage, is 100% secure and reliable, and we cannot guarantee its absolute security.</p>
+    <p>I value your trust and strive to use commercially acceptable means of protecting any information processed by my Apps and third-party services. However, remember that no method of transmission over the internet, or method of electronic storage, is 100% secure and reliable, and I cannot guarantee its absolute security.</p>
 
     <md-divider></md-divider>
 
     <h2>Links to Other Sites</h2>
-    <p>Our Apps may contain links to other sites or services. If you click on a third-party link, you will be directed to that site. Note that these external sites are not operated by us. Therefore, we strongly advise you to review the Privacy Policy of these websites. We have no control over and assume no responsibility for the content, privacy policies, or practices of any third-party sites or services.</p>
+    <p>My Apps may contain links to other sites or services. If you click on a third-party link, you will be directed to that site. Note that these external sites are not operated by me. Therefore, I strongly advise you to review the Privacy Policy of these websites. I have no control over and assume no responsibility for the content, privacy policies, or practices of any third-party sites or services.</p>
 
     <md-divider></md-divider>
 
     <h2>Children’s Privacy</h2>
-    <p>These Services do not address anyone under the age of 13 (or a higher age of digital consent if applicable in your region). We do not knowingly collect personally identifiable information from children. In the case we discover that a child under the applicable age of consent has provided us with personal information without verifiable parental consent, we will take steps to delete this information. If you are a parent or guardian and you are aware that your child has provided us with personal information, please contact us so that we can take necessary actions.</p>
+    <p>These Services do not address anyone under the age of 13 (or a higher age of digital consent if applicable in your region). I do not knowingly collect personally identifiable information from children. In the case I discover that a child under the applicable age of consent has provided me with personal information without verifiable parental consent, I will take steps to delete this information. If you are a parent or guardian and you are aware that your child has provided me with personal information, please contact me so that I can take necessary actions.</p>
 
     <md-divider></md-divider>
 
     <h2>Changes to This Privacy Policy</h2>
-    <p>We may update our Privacy Policy from time to time. Thus, you are advised to review this page periodically for any changes. We will notify you of any significant changes by posting the new Privacy Policy on this page and potentially through other means (e.g., an in-app notification or updating the "last updated" date). Changes to this Privacy Policy are effective when they are posted on this page.</p>
+    <p>I may update my Privacy Policy from time to time. Thus, you are advised to review this page periodically for any changes. I will notify you of any significant changes by posting the new Privacy Policy on this page and potentially through other means (e.g., an in-app notification or updating the "last updated" date). Changes to this Privacy Policy are effective when they are posted on this page.</p>
 
     <md-divider></md-divider>
 
-    <h2>Contact Us</h2>
-    <p>If you have any questions or suggestions about this Privacy Policy for Android Applications, do not hesitate to contact <strong>Mihai-Cristian Condrea (D4rK)</strong> at: <a href="mailto:d4rk7355608@gmail.com">d4rk7355608@gmail.com</a>.</p>
+    <h2>Contact me</h2>
+    <p>If you have any questions or suggestions about this Privacy Policy for Android Applications, do not hesitate to contact <strong>Mihai-Cristian Condrea </strong> at: <a href="mailto:contact.mihaicristiancondrea@gmail.com">contact.mihaicristiancondrea@gmail.com</a>.</p>
 </div>

--- a/pages/more/apps/terms-of-service-apps.html
+++ b/pages/more/apps/terms-of-service-apps.html
@@ -1,49 +1,49 @@
 <div id="termsOfServiceAppsPageContainer" class="page-section active">
-    <h1>Terms of Service for Our Android Applications</h1>
+    <h1>Terms of Service for My Android Applications</h1>
     <p class="last-updated-text">Effective Date: June 1, 2025</p>
 
     <img src="assets/images/terms_service_banner_agreement.png"
          alt="Illustration of a document or handshake representing agreement to terms"
          class="page-banner-image">
 
-    <p>Welcome to our Android applications (the "App" or "Apps", "Service") provided by <strong>Mihai-Cristian Condrea (operating under the alias "D4rK")</strong> ("we," "us," or "our"). These Terms of Service ("Terms") govern your use of our Apps. Please read them carefully before downloading or using any of our Apps.</p>
-    <p>By downloading, accessing, or using any of our Apps, you agree to be bound by these Terms and our <a href="#privacy-policy-end-user-software">Privacy Policy – End-User Software</a>. If you do not agree to these Terms, do not use our Apps.</p>
+    <p>Welcome to my Android applications (the "App" or "Apps", "Service") provided by <strong>Mihai-Cristian Condrea</strong> ("I," "me," or "my"). These Terms of Service ("Terms") govern your use of my Apps. Please read them carefully before downloading or using any of my Apps.</p>
+    <p>By downloading, accessing, or using any of my Apps, you agree to be bound by these Terms and my <a href="#privacy-policy-end-user-software">Privacy Policy – End-User Software</a>. If you do not agree to these Terms, do not use my Apps.</p>
 
     <md-divider></md-divider>
 
-    <h2>1. License to Use Our Apps</h2>
-    <p>We grant you a limited, non-exclusive, non-transferable, revocable license to use our Apps for your personal, non-commercial purposes, subject to these Terms.</p>
-    <p>You are not allowed to copy, modify, distribute, sell, or lease any part of our Apps or included software, nor may you reverse engineer or attempt to extract the source code of our Apps, unless laws prohibit these restrictions or you have our written permission. The Apps themselves, and all the trademarks, copyright, database rights, and other intellectual property rights related to them, still belong to Mihai-Cristian Condrea (D4rK).</p>
+    <h2>1. License to Use My Apps</h2>
+    <p>I grant you a limited, non-exclusive, non-transferable, revocable license to use my Apps for your personal, non-commercial purposes, subject to these Terms.</p>
+    <p>You are not allowed to copy, modify, distribute, sell, or lease any part of my Apps or included software, nor may you reverse engineer or attempt to extract the source code of my Apps, unless laws prohibit these restrictions or you have my written permission. The Apps themselves, and all the trademarks, copyright, database rights, and other intellectual property rights related to them, still belong to Mihai-Cristian Condrea.</p>
 
     <md-divider></md-divider>
 
     <h2>2. Age Requirements</h2>
-    <p>Our Apps are not intended for use by individuals under the age of 13 (or the applicable age of digital consent in your jurisdiction). If you are under this age, you may only use the Apps with the consent and supervision of a parent or legal guardian who agrees to be bound by these Terms.</p>
+    <p>My Apps are not intended for use by individuals under the age of 13 (or the applicable age of digital consent in your jurisdiction). If you are under this age, you may only use the Apps with the consent and supervision of a parent or legal guardian who agrees to be bound by these Terms.</p>
 
     <md-divider></md-divider>
 
     <h2>3. App Functionality and Updates</h2>
-    <p>Mihai-Cristian Condrea (D4rK) is committed to ensuring that the Apps are as useful and efficient as possible. For that reason, we reserve the right to make changes to the Apps or to charge for certain services or features, at any time and for any reason. We will never charge you for an App or its services without making it very clear to you exactly what you’re paying for.</p>
-    <p>Our Apps may store and process personal data as described in our <a href="#privacy-policy-end-user-software">Privacy Policy – End-User Software</a> to provide our Service. It’s your responsibility to keep your phone and access to the Apps secure. We therefore recommend that you do not jailbreak or root your phone, which is the process of removing software restrictions and limitations imposed by the official operating system of your device. It could make your phone vulnerable to malware/viruses/malicious programs, compromise your phone’s security features, and it could mean that our Apps won’t work properly or at all.</p>
-    <p>At some point, we may wish to update an App. The Apps are currently available on Android – the requirements for the system (and for any additional systems we decide to extend the availability of the Apps to) may change, and you’ll need to download the updates if you want to keep using the App. Mihai-Cristian Condrea (D4rK) does not promise that it will always update the Apps so that they are relevant to you and/or work with the Android version that you have installed on your device. However, you promise to always accept updates to the application when offered to you.</p>
+    <p>Mihai-Cristian Condrea is committed to ensuring that the Apps are as useful and efficient as possible. For that reason, I reserve the right to make changes to the Apps or to charge for certain services or features, at any time and for any reason. I will never charge you for an App or its services without making it very clear to you exactly what you’re paying for.</p>
+    <p>My Apps may store and process personal data as described in my <a href="#privacy-policy-end-user-software">Privacy Policy – End-User Software</a> to provide my Service. It’s your responsibility to keep your phone and access to the Apps secure. I therefore recommend that you do not jailbreak or root your phone, which is the process of removing software restrictions and limitations imposed by the official operating system of your device. It could make your phone vulnerable to malware/viruses/malicious programs, compromise your phone’s security features, and it could mean that my Apps won’t work properly or at all.</p>
+    <p>At some point, I may wish to update an App. The Apps are currently available on Android – the requirements for the system (and for any additional systems I decide to extend the availability of the Apps to) may change, and you’ll need to download the updates if you want to keep using the App. Mihai-Cristian Condrea does not promise that it will always update the Apps so that they are relevant to you and/or work with the Android version that you have installed on your device. However, you promise to always accept updates to the application when offered to you.</p>
 
     <md-divider></md-divider>
 
     <h2>4. In-App Purchases and Donations</h2>
-    <p>Some of our Apps may offer in-app purchases (IAPs) or opportunities to make voluntary donations (e.g., "Feast," "Dinner," "Coffee," "Lunch"). These are one-time purchases and are not subscriptions unless explicitly stated.</p>
+    <p>Some of my Apps may offer in-app purchases (IAPs) or opportunities to make voluntary donations (e.g., "Feast," "Dinner," "Coffee," "Lunch"). These are one-time purchases and are not subscriptions unless explicitly stated.</p>
     <ul>
-        <li><strong>Purpose of Donations:</strong> Donations are entirely voluntary and are intended to support the ongoing development, maintenance, and improvement of our Apps and other projects. They help us dedicate more time and resources to creating and enhancing our free offerings.</li>
+        <li><strong>Purpose of Donations:</strong> Donations are entirely voluntary and are intended to support the ongoing development, maintenance, and improvement of my Apps and other projects. They help me dedicate more time and resources to creating and enhancing my free offerings.</li>
         <li><strong>No Obligation:</strong> Making a donation does not entitle you to any additional features, content, or services beyond what is already available in the App, unless specifically described as a benefit of a particular IAP.</li>
-        <li><strong>Payment Processing:</strong> All IAPs and donations are processed through the Google Play Store's billing system. We do not collect or store your payment information.</li>
+        <li><strong>Payment Processing:</strong> All IAPs and donations are processed through the Google Play Store's billing system. I do not collect or store your payment information.</li>
     </ul>
 
     <h3>Refund Policy for In-App Purchases/Donations</h3>
-    <p>We adhere to the Google Play refund policies for all in-app purchases and donations made through our Apps.</p>
+    <p>I adhere to the Google Play refund policies for all in-app purchases and donations made through my Apps.</p>
     <ul>
         <li><strong>Eligibility via Google Play:</strong> You can typically request a refund directly from Google Play within 48 hours of the purchase. Please refer to Google Play's official support documentation for instructions on how to request a refund.</li>
-        <li><strong>Requests After 48 Hours:</strong> After the 48-hour window provided by Google Play has passed, refunds are generally not available unless required by applicable law. You may contact us directly at <a href="mailto:d4rk7355608@gmail.com">d4rk7355608@gmail.com</a> with your purchase details and reason for the request. However, granting refunds after this period is at our sole discretion.</li>
+        <li><strong>Requests After 48 Hours:</strong> After the 48-hour window provided by Google Play has passed, refunds are generally not available unless required by applicable law. You may contact me directly at <a href="mailto:contact.mihaicristiancondrea@gmail.com">contact.mihaicristiancondrea@gmail.com</a> with your purchase details and reason for the request. However, granting refunds after this period is at my sole discretion.</li>
         <li><strong>Non-Refundable Items:</strong> Unless otherwise required by law, digital products such as one-time donations or unlocked features via IAPs are considered final and non-refundable once purchased and delivered.</li>
-        <li><strong>Abuse of Policy:</strong> We reserve the right to refuse refund requests if we suspect abuse of this policy (e.g., repeated requests for the same item).</li>
+        <li><strong>Abuse of Policy:</strong> I reserve the right to refuse refund requests if I suspect abuse of this policy (e.g., repeated requests for the same item).</li>
     </ul>
     <p>For any issues related to unauthorized or fraudulent purchases, please contact Google Play support immediately.</p>
 
@@ -54,49 +54,49 @@
     <md-divider></md-divider>
 
     <h2>5. Third-Party Services</h2>
-    <p>Our Apps may use or integrate with third-party services that have their own Terms and Conditions. By using our Apps, you may also be subject to the terms of these third parties.</p>
-    <p>Links to Terms and Conditions of key third-party service providers used by our Apps:</p>
+    <p>My Apps may use or integrate with third-party services that have their own Terms and Conditions. By using my Apps, you may also be subject to the terms of these third parties.</p>
+    <p>Links to Terms and Conditions of key third-party service providers used by my Apps:</p>
     <ul>
         <li><a href="https://policies.google.com/terms" target="_blank" rel="noopener noreferrer">Google Play Services</a></li>
         <li><a href="https://developers.google.com/admob/terms" target="_blank" rel="noopener noreferrer">AdMob (Google)</a></li>
         <li><a href="https://firebase.google.com/terms/analytics" target="_blank" rel="noopener noreferrer">Google Analytics for Firebase</a></li>
         <li><a href="https://firebase.google.com/terms/crashlytics" target="_blank" rel="noopener noreferrer">Firebase Crashlytics</a></li>
     </ul>
-    <p>We are not responsible for the practices or content of these third-party services.</p>
+    <p>I am not responsible for the practices or content of these third-party services.</p>
 
     <md-divider></md-divider>
 
     <h2>6. Internet Connection and Data Charges</h2>
-    <p>Certain functions of our Apps will require an active internet connection. The connection can be Wi-Fi or provided by your mobile network provider. Mihai-Cristian Condrea (D4rK) cannot take responsibility for an App not working at full functionality if you don’t have access to Wi-Fi, and you don’t have any of your data allowance left.</p>
-    <p>If you’re using an App outside of an area with Wi-Fi, you should remember that the terms of the agreement with your mobile network provider will still apply. As a result, you may be charged by your mobile provider for the cost of data for the duration of the connection while accessing the App, or other third-party charges. In using an App, you’re accepting responsibility for any such charges, including roaming data charges if you use the App outside of your home territory (i.e., region or country) without turning off data roaming. If you are not the bill payer for the device on which you’re using an App, please be aware that we assume that you have received permission from the bill payer for using the App.</p>
+    <p>Certain functions of my Apps will require an active internet connection. The connection can be Wi-Fi or provided by your mobile network provider. Mihai-Cristian Condrea cannot take responsibility for an App not working at full functionality if you don’t have access to Wi-Fi, and you don’t have any of your data allowance left.</p>
+    <p>If you’re using an App outside of an area with Wi-Fi, you should remember that the terms of the agreement with your mobile network provider will still apply. As a result, you may be charged by your mobile provider for the cost of data for the duration of the connection while accessing the App, or other third-party charges. In using an App, you’re accepting responsibility for any such charges, including roaming data charges if you use the App outside of your home territory (i.e., region or country) without turning off data roaming. If you are not the bill payer for the device on which you’re using an App, please be aware that I assume that you have received permission from the bill payer for using the App.</p>
 
     <md-divider></md-divider>
 
     <h2>7. Limitation of Liability</h2>
-    <p>TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL MIHAI-CRISTIAN CONDREA (D4RK), NOR ITS DIRECTORS, EMPLOYEES, PARTNERS, AGENTS, SUPPLIERS, OR AFFILIATES, BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL OR PUNITIVE DAMAGES, INCLUDING WITHOUT LIMITATION, LOSS OF PROFITS, DATA, USE, GOODWILL, OR OTHER INTANGIBLE LOSSES, RESULTING FROM (I) YOUR ACCESS TO OR USE OF OR INABILITY TO ACCESS OR USE THE SERVICE; (II) ANY CONDUCT OR CONTENT OF ANY THIRD PARTY ON THE SERVICE; (III) ANY CONTENT OBTAINED FROM THE SERVICE; AND (IV) UNAUTHORIZED ACCESS, USE OR ALTERATION OF YOUR TRANSMISSIONS OR CONTENT, WHETHER BASED ON WARRANTY, CONTRACT, TORT (INCLUDING NEGLIGENCE) OR ANY OTHER LEGAL THEORY, WHETHER OR NOT WE HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGE, AND EVEN IF A REMEDY SET FORTH HEREIN IS FOUND TO HAVE FAILED OF ITS ESSENTIAL PURPOSE.</p>
-    <p>WE ENDEAVOR TO ENSURE THAT OUR APPS ARE UPDATED AND CORRECT AT ALL TIMES, BUT WE DO RELY ON THIRD PARTIES TO PROVIDE INFORMATION TO US SO THAT WE CAN MAKE IT AVAILABLE TO YOU. MIHAI-CRISTIAN CONDREA (D4RK) ACCEPTS NO LIABILITY FOR ANY LOSS, DIRECT OR INDIRECT, YOU EXPERIENCE AS A RESULT OF RELYING WHOLLY ON THE FUNCTIONALITY OF ANY APP.</p>
+    <p>TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL MIHAI-CRISTIAN CONDREA, NOR ITS DIRECTORS, EMPLOYEES, PARTNERS, AGENTS, SUPPLIERS, OR AFFILIATES, BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL OR PUNITIVE DAMAGES, INCLUDING WITHOUT LIMITATION, LOSS OF PROFITS, DATA, USE, GOODWILL, OR OTHER INTANGIBLE LOSSES, RESULTING FROM (I) YOUR ACCESS TO OR USE OF OR INABILITY TO ACCESS OR USE THE SERVICE; (II) ANY CONDUCT OR CONTENT OF ANY THIRD PARTY ON THE SERVICE; (III) ANY CONTENT OBTAINED FROM THE SERVICE; AND (IV) UNAUTHORIZED ACCESS, USE OR ALTERATION OF YOUR TRANSMISSIONS OR CONTENT, WHETHER BASED ON WARRANTY, CONTRACT, TORT (INCLUDING NEGLIGENCE) OR ANY OTHER LEGAL THEORY, WHETHER OR NOT WE HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGE, AND EVEN IF A REMEDY SET FORTH HEREIN IS FOUND TO HAVE FAILED OF ITS ESSENTIAL PURPOSE.</p>
+    <p>WE ENDEAVOR TO ENSURE THAT OUR APPS ARE UPDATED AND CORRECT AT ALL TIMES, BUT WE DO RELY ON THIRD PARTIES TO PROVIDE INFORMATION TO US SO THAT WE CAN MAKE IT AVAILABLE TO YOU. MIHAI-CRISTIAN CONDREA ACCEPTS NO LIABILITY FOR ANY LOSS, DIRECT OR INDIRECT, YOU EXPERIENCE AS A RESULT OF RELYING WHOLLY ON THE FUNCTIONALITY OF ANY APP.</p>
 
     <md-divider></md-divider>
 
     <h2>8. Termination</h2>
-    <p>We may terminate or suspend your access to our Apps immediately, without prior notice or liability, for any reason whatsoever, including without limitation if you breach the Terms.</p>
+    <p>I may terminate or suspend your access to my Apps immediately, without prior notice or liability, for any reason whatsoever, including without limitation if you breach the Terms.</p>
     <p>Upon termination, your right to use the Apps will immediately cease. (a) The rights and licenses granted to you in these terms will end; (b) you must stop using the App, and (if needed) delete it from your device. All provisions of the Terms which by their nature should survive termination shall survive termination, including, without limitation, ownership provisions, warranty disclaimers, indemnity, and limitations of liability.</p>
 
     <md-divider></md-divider>
 
     <h2>9. Governing Law</h2>
     <p>These Terms shall be governed and construed in accordance with the laws of Romania, without regard to its conflict of law provisions.</p>
-    <p>Our failure to enforce any right or provision of these Terms will not be considered a waiver of those rights. If any provision of these Terms is held to be invalid or unenforceable by a court, the remaining provisions of these Terms will remain in effect. These Terms constitute the entire agreement between us regarding our Service and supersede and replace any prior agreements we might have had between us regarding the Service.</p>
+    <p>My failure to enforce any right or provision of these Terms will not be considered a waiver of those rights. If any provision of these Terms is held to be invalid or unenforceable by a court, the remaining provisions of these Terms will remain in effect. These Terms constitute the entire agreement between me regarding my Service and supersede and replace any prior agreements I might have had between me regarding the Service.</p>
 
     <md-divider></md-divider>
 
     <h2>10. Changes to These Terms</h2>
-    <p>We reserve the right, at our sole discretion, to modify or replace these Terms at any time. If a revision is material, we will try to provide at least 30 days' notice prior to any new terms taking effect, typically by posting the new Terms on this page or through an in-app notification. What constitutes a material change will be determined at our sole discretion.</p>
-    <p>By continuing to access or use our Service after those revisions become effective, you agree to be bound by the revised terms. If you do not agree to the new terms, please stop using the Service.</p>
+    <p>I reserve the right, at my sole discretion, to modify or replace these Terms at any time. If a revision is material, I will try to provide at least 30 days' notice prior to any new terms taking effect, typically by posting the new Terms on this page or through an in-app notification. What constitutes a material change will be determined at my sole discretion.</p>
+    <p>By continuing to access or use my Service after those revisions become effective, you agree to be bound by the revised terms. If you do not agree to the new terms, please stop using the Service.</p>
     <p>You are advised to review these Terms periodically for any changes.</p>
 
     <md-divider></md-divider>
 
-    <h2>11. Contact Us</h2>
-    <p>If you have any questions or suggestions about these Terms of Service, do not hesitate to contact <strong>Mihai-Cristian Condrea (D4rK)</strong> at: <a href="mailto:d4rk7355608@gmail.com">d4rk7355608@gmail.com</a>.</p>
+    <h2>11. Contact me</h2>
+    <p>If you have any questions or suggestions about these Terms of Service, do not hesitate to contact <strong>Mihai-Cristian Condrea </strong> at: <a href="mailto:contact.mihaicristiancondrea@gmail.com">contact.mihaicristiancondrea@gmail.com</a>.</p>
 </div>

--- a/pages/more/code-of-conduct.html
+++ b/pages/more/code-of-conduct.html
@@ -10,13 +10,13 @@
 
     <md-divider></md-divider>
 
-    <h2>Our Pledge</h2>
+    <h2>My Pledge</h2>
     <p>In the interest of fostering an open and welcoming environment, I pledge to ensure that all interactions are free of harassment, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.</p>
     <p>I pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy professional environment.</p>
 
     <md-divider></md-divider>
 
-    <h2>Our Standards</h2>
+    <h2>My Standards</h2>
     <p>Examples of behavior that contribute to creating a positive environment include:</p>
     <ul>
         <li>Using welcoming and inclusive language.</li>
@@ -46,7 +46,7 @@
     <p>This Code of Conduct applies to all interactions related to this website, my projects, and my professional online presence. This includes, but is not limited to:</p>
     <ul>
         <li>Comments on blog posts (if applicable).</li>
-        <li>Communication via email (e.g., to <a href="mailto:d4rk7355608@gmail.com">d4rk7355608@gmail.com</a>).</li>
+        <li>Communication via email (e.g., to <a href="mailto:contact.mihaicristiancondrea@gmail.com">contact.mihaicristiancondrea@gmail.com</a>).</li>
         <li>Interactions on social media platforms where I represent my work.</li>
         <li>Contributions to or discussions about my open-source projects on platforms like GitHub.</li>
     </ul>
@@ -56,7 +56,7 @@
 
     <h2>Enforcement & Reporting</h2>
     <p>I am responsible for clarifying and enforcing the standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that I deem inappropriate, threatening, offensive, or harmful.</p>
-    <p>Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting me at <a href="mailto:d4rk7355608@gmail.com">d4rk7355608@gmail.com</a>. All reports will be reviewed and investigated, and will result in a response deemed necessary and appropriate to the circumstances. This may include warnings, blocking from communication channels, or other actions as outlined below.</p>
+    <p>Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting me at <a href="mailto:contact.mihaicristiancondrea@gmail.com">contact.mihaicristiancondrea@gmail.com</a>. All reports will be reviewed and investigated, and will result in a response deemed necessary and appropriate to the circumstances. This may include warnings, blocking from communication channels, or other actions as outlined below.</p>
     <p>I hold the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that I deem inappropriate.</p>
 
     <h3>Enforcement Guidelines</h3>

--- a/pages/more/privacy-policy.html
+++ b/pages/more/privacy-policy.html
@@ -5,78 +5,78 @@
    <img src="assets/images/privacy_banner_friendly_guardian.png"
         alt="Illustration of a friendly guardian representing data privacy">
 
-    <p>Welcome to Mihai's Profile Website ("us", "we", or "our"). We are committed to protecting your privacy. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you visit our website (the "Service"). Please read this privacy policy carefully. If you do not agree with the terms of this privacy policy, please do not access the site.</p>
-    <p>We reserve the right to make changes to this Privacy Policy at any time and for any reason. We will alert you about any changes by updating the "Last updated" date of this Privacy Policy. You are encouraged to periodically review this Privacy Policy to stay informed of updates.</p>
+    <p>Welcome to Mihai's Profile Website ("me", "I", or "my"). I am committed to protecting your privacy. This Privacy Policy explains how I collect, use, disclose, and safeguard your information when you visit my website (the "Service"). Please read this privacy policy carefully. If you do not agree with the terms of this privacy policy, please do not access the site.</p>
+    <p>I reserve the right to make changes to this Privacy Policy at any time and for any reason. I will alert you about any changes by updating the "Last updated" date of this Privacy Policy. You are encouraged to periodically review this Privacy Policy to stay informed of updates.</p>
 
     <md-divider></md-divider>
 
-    <h2>Information We Collect</h2>
-    <p>We may collect information about you in a variety of ways. The information we may collect on the Service includes:</p>
+    <h2>Information I Collect</h2>
+    <p>I may collect information about you in a variety of ways. The information I may collect on the Service includes:</p>
 
     <h3>Usage Data</h3>
-    <p>Usage Data is collected automatically when you use the Service. This data may include information such as your Device's Internet Protocol (IP) address, browser type, browser version, the pages of our Service that you visit, the time and date of your visit, the time spent on those pages, unique device identifiers, and other diagnostic data. This information is used for analytical purposes to improve our Service.</p>
+    <p>Usage Data is collected automatically when you use the Service. This data may include information such as your Device's Internet Protocol (IP) address, browser type, browser version, the pages of my Service that you visit, the time and date of your visit, the time spent on those pages, unique device identifiers, and other diagnostic data. This information is used for analytical purposes to improve my Service.</p>
 
     <h3>Client-Side Stored Data (Local Storage)</h3>
-    <p>To enhance your experience, our Service utilizes browser local storage to remember certain preferences. Specifically, we may store:</p>
+    <p>To enhance your experience, my Service utilizes browser local storage to remember certain preferences. Specifically, I may store:</p>
     <ul>
-        <li><strong>Theme Preferences:</strong> Your selected theme (e.g., light, dark, or auto mode) is stored locally on your device so that your preference is remembered on subsequent visits. This data is stored only in your browser and is not transmitted to our servers.</li>
+        <li><strong>Theme Preferences:</strong> Your selected theme (e.g., light, dark, or auto mode) is stored locally on your device so that your preference is remembered on subsequent visits. This data is stored only in your browser and is not transmitted to my servers.</li>
     </ul>
 
     <h3>Data from Third-Party Services</h3>
-    <p>Our Service integrates with and links to third-party services to provide certain functionalities:</p>
+    <p>My Service integrates with and links to third-party services to provide certain functionalities:</p>
     <ul>
-        <li><strong>Blogger API (Google):</strong> To display the latest news/blog posts, we fetch data from the Blogger API. This involves using an API key configured within our application. Google's services are governed by their own <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>. We do not send any of your personal data to Blogger, nor do we receive personal data about you from Blogger, other than the public blog content.</li>
-        <li><strong>External Links:</strong> Our Service contains links to external websites (e.g., GitHub, social media platforms, Blogger, music platforms). If you click on a third-party link, you will be directed to that third party's site. We strongly advise you to review the Privacy Policy of every site you visit. We have no control over and assume no responsibility for the content, privacy policies, or practices of any third-party sites or services.</li>
+        <li><strong>Blogger API (Google):</strong> To display the latest news/blog posts, I fetch data from the Blogger API. This involves using an API key configured within my application. Google's services are governed by their own <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>. I do not send any of your personal data to Blogger, nor do I receive personal data about you from Blogger, other than the public blog content.</li>
+        <li><strong>External Links:</strong> My Service contains links to external websites (e.g., GitHub, social media platforms, Blogger, music platforms). If you click on a third-party link, you will be directed to that third party's site. I strongly advise you to review the Privacy Policy of every site you visit. I have no control over and assume no responsibility for the content, privacy policies, or practices of any third-party sites or services.</li>
     </ul>
 
     <md-divider></md-divider>
 
     <h2>Use of Your Information</h2>
-    <p>Having accurate information permits us to provide you with a smooth, efficient, and customized experience. Specifically, we may use information collected about you via the Service to:</p>
+    <p>Having accurate information permits me to provide you with a smooth, efficient, and customized experience. Specifically, I may use information collected about you via the Service to:</p>
     <ul>
-        <li>Provide and maintain our Service, including monitoring the usage of our Service.</li>
+        <li>Provide and maintain my Service, including monitoring the usage of my Service.</li>
         <li>Improve the Service by analyzing usage trends and user interaction.</li>
         <li>Remember your preferences (like theme settings) for subsequent visits.</li>
-        <li>Respond to your direct inquiries if you contact us via the provided email address.</li>
+        <li>Respond to your direct inquiries if you contact me via the provided email address.</li>
     </ul>
 
     <md-divider></md-divider>
 
     <h2>Tracking Technologies (Cookies and Local Storage)</h2>
-    <p>We primarily use browser <strong>Local Storage</strong> for functionality purposes as described above (e.g., theme settings). Local Storage data remains on your device until manually cleared by you.</p>
-    <p>While our Service itself does not extensively use cookies for tracking users, some third-party services we link to or embed content from (like Blogger, Google Fonts, Font Awesome, or social media platforms) may use cookies or other tracking technologies. These are governed by the privacy policies of those third parties. You can typically manage cookie preferences through your browser settings.</p>
+    <p>I primarily use browser <strong>Local Storage</strong> for functionality purposes as described above (e.g., theme settings). Local Storage data remains on your device until manually cleared by you.</p>
+    <p>While my Service itself does not extensively use cookies for tracking users, some third-party services I link to or embed content from (like Blogger, Google Fonts, Font Awesome, or social media platforms) may use cookies or other tracking technologies. These are governed by the privacy policies of those third parties. You can typically manage cookie preferences through your browser settings.</p>
 
     <md-divider></md-divider>
 
     <h2>Advertising</h2>
-    <p>This website currently does not display third-party advertisements directly. However, please refer to our "Understanding Advertising in Our Applications" page for information on how advertising may be used in other applications we develop. If we introduce advertising on this website in the future, this Privacy Policy will be updated accordingly.</p>
+    <p>This website currently does not display third-party advertisements directly. However, please refer to my "Understanding Advertising in My Applications" page for information on how advertising may be used in other applications I develop. If I introduce advertising on this website in the future, this Privacy Policy will be updated accordingly.</p>
 
     <md-divider></md-divider>
 
     <h2>Security of Your Information</h2>
-    <p>We use administrative, technical, and physical security measures to help protect your information. While we have taken reasonable steps to secure the information we process (primarily aggregated usage data and client-side preferences), please be aware that despite our efforts, no security measures are perfect or impenetrable, and no method of data transmission can be guaranteed against any interception or other type of misuse.</p>
+    <p>I use administrative, technical, and physical security measures to help protect your information. While I have taken reasonable steps to secure the information I process (primarily aggregated usage data and client-side preferences), please be aware that despite my efforts, no security measures are perfect or impenetrable, and no method of data transmission can be guaranteed against any interception or other type of misuse.</p>
 
     <md-divider></md-divider>
 
     <h2>Children's Privacy</h2>
-    <p>Our Service is not intended for individuals under the age of 13 (or the relevant age of digital consent in your jurisdiction). We do not knowingly collect personal data from children. If you are a parent or guardian and you are aware that your child has provided us with Personal Data without your consent, please contact us. If we become aware that we have collected Personal Data from children without verification of parental consent, we will take steps to remove that information.</p>
+    <p>My Service is not intended for individuals under the age of 13 (or the relevant age of digital consent in your jurisdiction). I do not knowingly collect personal data from children. If you are a parent or guardian and you are aware that your child has provided me with Personal Data without your consent, please contact me. If I become aware that I have collected Personal Data from children without verification of parental consent, I will take steps to remove that information.</p>
 
     <md-divider></md-divider>
 
     <h2>Your Privacy Rights</h2>
-    <p>Depending on your jurisdiction, you may have certain rights regarding your personal data, such as the right to access, correct, or delete information, or to object to certain processing. Since we collect minimal personal data directly through this Service, these rights primarily apply to the data held by third-party services you interact with through our links, or data stored locally in your browser (which you can clear).</p>
+    <p>Depending on your jurisdiction, you may have certain rights regarding your personal data, such as the right to access, correct, or delete information, or to object to certain processing. Since I collect minimal personal data directly through this Service, these rights primarily apply to the data held by third-party services you interact with through my links, or data stored locally in your browser (which you can clear).</p>
     <p>For data stored in your browser's local storage (like theme preferences), you can clear this data by clearing your browser's cache and site data.</p>
 
     <md-divider></md-divider>
 
     <h2>Changes to This Privacy Policy</h2>
-    <p>We may update this Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page and updating the "Last updated" date at the top. You are advised to review this Privacy Policy periodically for any changes.</p>
+    <p>I may update this Privacy Policy from time to time. I will notify you of any changes by posting the new Privacy Policy on this page and updating the "Last updated" date at the top. You are advised to review this Privacy Policy periodically for any changes.</p>
 
     <md-divider></md-divider>
 
-    <h2>Contact Us</h2>
-    <p>If you have any questions or comments about this Privacy Policy, please contact us:</p>
+    <h2>Contact me</h2>
+    <p>If you have any questions or comments about this Privacy Policy, please contact me:</p>
     <ul>
-        <li>By email: <a href="mailto:d4rk7355608@gmail.com">d4rk7355608@gmail.com</a></li>
+        <li>By email: <a href="mailto:contact.mihaicristiancondrea@gmail.com">contact.mihaicristiancondrea@gmail.com</a></li>
     </ul>
 </div>


### PR DESCRIPTION
## Summary
- show former alias on profile header
- update contact links to use the new email address
- rewrite policy pages to use first-person pronouns

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68828970070c832d82560111c463fb7a