### PR TITLE
Fix PDF generation and preview sizing

### DIFF
--- a/assets/css/cv.css
+++ b/assets/css/cv.css
@@ -59,7 +59,7 @@
 #cvPage .dynamic-list .list-item{display:flex;align-items:center;gap:8px;margin-bottom:8px;}
 #cvPage .dynamic-list .list-item input{flex-grow:1;}
 #cvPage .complex-item-form>div{background-color: var(--md-sys-color-surface-container-low);border:1px solid var(--md-sys-color-surface-variant);padding:16px;border-radius:12px;margin-bottom:16px;display:flex;flex-direction:column;gap:16px;}
-#cvPage #cv-preview{width:800px;background:var(--md-sys-color-surface);box-shadow:0 8px 24px rgba(0,0,0,0.1);border:1px solid var(--app-border-color);}
+#cvPage #cv-preview{width:800px;background:var(--md-sys-color-surface);box-shadow:0 8px 24px rgba(0,0,0,0.1);border:1px solid var(--app-border-color);height:auto;min-height:auto;}
 #cvPage .cv-content{display:flex;}
 #cvPage .cv-left{background: var(--md-sys-color-surface-container-high);width:35%;padding:40px 30px;color:#333;}
 #cvPage .cv-right{width:65%;padding:40px 30px;}

--- a/assets/js/cv.js
+++ b/assets/js/cv.js
@@ -136,13 +136,32 @@ function updateComplexList(sectionId) {
 
 function initPdfDownload() {
     const btn = document.getElementById('download-cv');
-    if (btn) {
-        btn.addEventListener('click', () => {
-            const cvElement = document.getElementById('cv-preview');
-            const opt = { margin:0, filename:'Mihai-Condrea-CV.pdf', image:{type:'jpeg',quality:1.0}, html2canvas:{scale:4,useCORS:true,dpi:300,letterRendering:true}, jsPDF:{unit:'px',format:'a4',orientation:'portrait'} };
-            html2pdf().from(cvElement).set(opt).save();
-        });
-    }
+    if (!btn) return;
+    btn.addEventListener('click', async () => {
+        const cvElement = document.getElementById('cv-preview');
+
+        await document.fonts.ready;
+        const images = Array.from(cvElement.querySelectorAll('img'))
+            .map(img => img.complete ? Promise.resolve() : new Promise(res => { img.onload = img.onerror = res; }));
+        await Promise.all(images);
+
+        const opt = {
+            margin: 0,
+            filename: 'Mihai-Condrea-CV.pdf',
+            image: { type: 'jpeg', quality: 1.0 },
+            html2canvas: {
+                scale: 4,
+                useCORS: true,
+                dpi: 300,
+                letterRendering: true,
+                windowWidth: cvElement.scrollWidth,
+                windowHeight: cvElement.scrollHeight
+            },
+            jsPDF: { unit: 'pt', format: 'a4', orientation: 'portrait' }
+        };
+
+        html2pdf().from(cvElement).set(opt).save();
+    });
 }
 
 function initialize() {


### PR DESCRIPTION
## Summary
- make preview container auto-height so long CVs aren't clipped
- wait for fonts and images before generating the PDF
- size html2canvas capture to the scrollable preview

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6885f2bef8b8832db5d3b0f0b728d475