### PR TITLE
Fix resume init

### DIFF
--- a/assets/js/resume.js
+++ b/assets/js/resume.js
@@ -197,8 +197,43 @@ function prepareAndPrintResume() {
 }
 
 
+let markedLoadPromise;
+
+function ensureMarkedLoaded() {
+    if (window.marked) return Promise.resolve();
+    if (markedLoadPromise) return markedLoadPromise;
+    markedLoadPromise = new Promise(resolve => {
+        const script = document.createElement('script');
+        script.src = 'https://cdn.jsdelivr.net/npm/marked/marked.min.js';
+        script.onload = resolve;
+        script.onerror = resolve;
+        document.head.appendChild(script);
+    });
+    return markedLoadPromise;
+}
+
+function ensureResumeStyles() {
+    const head = document.head;
+    if (!document.querySelector('link[href="assets/css/resume.css"]')) {
+        const link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = 'assets/css/resume.css';
+        head.appendChild(link);
+    }
+    if (!document.querySelector('link[href="assets/css/print.css"]')) {
+        const link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = 'assets/css/print.css';
+        link.media = 'print';
+        head.appendChild(link);
+    }
+}
+
 function initResumePage() {
-    setupRealtimeUpdates();
-    setupMode();
-    document.fonts.ready.then(initialize);
+    ensureResumeStyles();
+    ensureMarkedLoaded().then(() => {
+        setupRealtimeUpdates();
+        setupMode();
+        document.fonts.ready.then(initialize);
+    });
 }


### PR DESCRIPTION
## Summary
- lazy-load resources required for the resume page so preview works

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6888e3fa1104832db6419ee85f9a100e