### PR TITLE
Finalize projects page

### DIFF
--- a/pages/drawer/projects.html
+++ b/pages/drawer/projects.html
@@ -2,14 +2,12 @@
   <h1>Projects</h1>
   <p class="projects-intro">A selection of my work using Material Design.</p>
   <md-tabs id="projectsFilterTabs" style="margin-bottom:1rem;">
-    <md-primary-tab data-category="featured" active>Featured</md-primary-tab>
-    <md-primary-tab data-category="all">All</md-primary-tab>
+    <md-primary-tab data-category="all" active>All</md-primary-tab>
     <md-primary-tab data-category="web">Web</md-primary-tab>
-    <md-primary-tab data-category="desktop">Desktop</md-primary-tab>
     <md-primary-tab data-category="android">Android</md-primary-tab>
   </md-tabs>
   <div class="projects-list">
-    <md-filled-card class="project-entry" data-category="featured web">
+    <md-filled-card class="project-entry" data-category="web">
       <div class="project-content">
         <div class="project-info">
           <h2>Profile Website</h2>
@@ -22,6 +20,106 @@
           <div class="carousel">
             <img class="carousel-slide active" src="https://via.placeholder.com/600x400.png?text=Website+1" alt="Profile Website screenshot" loading="lazy">
             <img class="carousel-slide" src="https://via.placeholder.com/600x400.png?text=Website+2" alt="Profile Website screenshot 2" loading="lazy">
+            <button class="prev" aria-label="Previous">
+              <span class="material-symbols-outlined">chevron_left</span>
+            </button>
+            <button class="next" aria-label="Next">
+              <span class="material-symbols-outlined">chevron_right</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </md-filled-card>
+    <md-filled-card class="project-entry" data-category="android">
+      <div class="project-content">
+        <div class="project-info">
+          <h2>AppToolkit for Android</h2>
+          <div class="date-range">2025&nbsp;&ndash;&nbsp;Present</div>
+          <p>A showcase of the reusable components, screens, and architecture used across my applications. It serves as a live demo, featuring Jetpack Compose UI, Material You theming, and modern fade-through screen transitions.</p>
+        </div>
+        <div class="project-media">
+          <div class="carousel">
+            <img class="carousel-slide active" src="https://via.placeholder.com/600x400.png?text=Project" alt="AppToolkit screenshot" loading="lazy">
+            <button class="prev" aria-label="Previous">
+              <span class="material-symbols-outlined">chevron_left</span>
+            </button>
+            <button class="next" aria-label="Next">
+              <span class="material-symbols-outlined">chevron_right</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </md-filled-card>
+    <md-filled-card class="project-entry" data-category="android">
+      <div class="project-content">
+        <div class="project-info">
+          <h2>Android Studio Tutorials</h2>
+          <div class="date-range">2022&nbsp;&ndash;&nbsp;Present</div>
+          <p>A pair of educational apps designed to teach beginners Android development with either Java or Kotlin/XML. The tutorials are available offline and include code snippets, ready-to-use layouts, and an AI Companion for assistance.</p>
+        </div>
+        <div class="project-media">
+          <div class="carousel">
+            <img class="carousel-slide active" src="https://via.placeholder.com/600x400.png?text=Project" alt="Android Studio Tutorials screenshot" loading="lazy">
+            <button class="prev" aria-label="Previous">
+              <span class="material-symbols-outlined">chevron_left</span>
+            </button>
+            <button class="next" aria-label="Next">
+              <span class="material-symbols-outlined">chevron_right</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </md-filled-card>
+    <md-filled-card class="project-entry" data-category="android">
+      <div class="project-content">
+        <div class="project-info">
+          <h2>Smart Cleaner for Android</h2>
+          <div class="date-range">2021&nbsp;&ndash;&nbsp;Present</div>
+          <p>A utility app providing a one-tap solution for freeing up device space and managing performance. It is a free, ad-supported tool for Android 8.0+ devices.</p>
+        </div>
+        <div class="project-media">
+          <div class="carousel">
+            <img class="carousel-slide active" src="https://via.placeholder.com/600x400.png?text=Project" alt="Smart Cleaner screenshot" loading="lazy">
+            <button class="prev" aria-label="Previous">
+              <span class="material-symbols-outlined">chevron_left</span>
+            </button>
+            <button class="next" aria-label="Next">
+              <span class="material-symbols-outlined">chevron_right</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </md-filled-card>
+    <md-filled-card class="project-entry" data-category="android">
+      <div class="project-content">
+        <div class="project-info">
+          <h2>Weddix – Create/Manage Events</h2>
+          <div class="date-range">2024&nbsp;&ndash;&nbsp;Present</div>
+          <p>An event-planning tool designed to make organizing a wedding or other event simple and stress-free. It helps users manage guest lists, track tasks, and control budgets with an intuitive drag-and-drop interface.</p>
+        </div>
+        <div class="project-media">
+          <div class="carousel">
+            <img class="carousel-slide active" src="https://via.placeholder.com/600x400.png?text=Project" alt="Weddix screenshot" loading="lazy">
+            <button class="prev" aria-label="Previous">
+              <span class="material-symbols-outlined">chevron_left</span>
+            </button>
+            <button class="next" aria-label="Next">
+              <span class="material-symbols-outlined">chevron_right</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </md-filled-card>
+    <md-filled-card class="project-entry" data-category="android">
+      <div class="project-content">
+        <div class="project-info">
+          <h2>Collection of Utility Apps</h2>
+          <div class="date-range">2022&nbsp;&ndash;&nbsp;Present</div>
+          <p>A suite of small, functional apps to solve everyday problems. This collection includes the Shopping Cart Calculator, Low Brightness screen dimmer, Music Sleep Timer Plus, the versatile QR &amp; Bar Code Scanner Plus, and the Net Probe network tool.</p>
+        </div>
+        <div class="project-media">
+          <div class="carousel">
+            <img class="carousel-slide active" src="https://via.placeholder.com/600x400.png?text=Project" alt="Collection of Utility Apps screenshot" loading="lazy">
             <button class="prev" aria-label="Previous">
               <span class="material-symbols-outlined">chevron_left</span>
             </button>
@@ -45,7 +143,6 @@
       const cat = tab.dataset.category;
       projects.forEach(p => {
         if (cat === 'all') { p.style.display = ''; return; }
-        if (cat === 'featured') { p.style.display = p.dataset.category.includes('featured') ? '' : 'none'; return; }
         p.style.display = p.dataset.category.includes(cat) ? '' : 'none';
       });
     });


### PR DESCRIPTION
## Summary
- trim Projects page navigation to only All, Web, and Android tabs
- display 5 Android projects and the existing Profile Website project
- simplify filtering logic now that Featured tab is gone

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68891f2f7780832d84174b902029cc45