### PR TITLE
Refactor navigation drawer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains the source for a personal profile site built as a small
 ## Features
 
 - **Material Design Components** – UI is styled with Google's Material Web Components.
-- **Navigation Drawer** – A slide‑out drawer provides access to the home page, blog link, music link and a "More" section with additional pages.
+- **Navigation Drawer** – A slide‑out drawer lists Home, Blogs, Music, Projects and collapsible "About" and "Android Apps" sections.
 - **Light/Dark Theme** – A theme toggle stores your preference in `localStorage` and can automatically match the system theme.
 - **Blogger Integration** – The home page fetches recent blog posts from Blogger using the Blogger API.
 - **Client‑Side Routing** – JavaScript loads internal pages without a full reload (privacy policy, code of conduct, app related info, etc.).
@@ -41,7 +41,7 @@ LICENSE                   # GPLv3 license
 
 The router loads pages based on URL fragments (e.g., `#privacy-policy`). Important fragments include:
 
-- `#privacy-policy` – Privacy Policy
+- `#privacy-policy` – Privacy & Cookies
 - `#code-of-conduct` – Code of Conduct
 - `#privacy-policy-end-user-software` – Privacy Policy – End-User Software
 - `#terms-of-service-end-user-software` – Terms of Service – End-User Software

--- a/assets/js/navigationDrawer.js
+++ b/assets/js/navigationDrawer.js
@@ -1,5 +1,5 @@
 let menuButton, navDrawer, closeDrawerButton, drawerOverlay,
-    moreToggle, moreContent, appsToggle, appsContent;
+    aboutToggle, aboutContent, androidAppsToggle, androidAppsContent;
 
 /**
  * Initializes the navigation drawer functionality.
@@ -10,10 +10,10 @@ function initNavigationDrawer() {
     navDrawer = getDynamicElement('navDrawer');
     closeDrawerButton = getDynamicElement('closeDrawerButton');
     drawerOverlay = getDynamicElement('drawerOverlay');
-    moreToggle = getDynamicElement('moreToggle');
-    moreContent = getDynamicElement('moreContent');
-    appsToggle = getDynamicElement('appsToggle');
-    appsContent = getDynamicElement('appsContent');
+    aboutToggle = getDynamicElement('aboutToggle');
+    aboutContent = getDynamicElement('aboutContent');
+    androidAppsToggle = getDynamicElement('androidAppsToggle');
+    androidAppsContent = getDynamicElement('androidAppsContent');
 
     if (menuButton) menuButton.addEventListener('click', openDrawer);
     if (closeDrawerButton) closeDrawerButton.addEventListener('click', closeDrawer);
@@ -25,8 +25,8 @@ function initNavigationDrawer() {
         }
     });
 
-    _initToggleSection(moreToggle, moreContent);
-    _initToggleSection(appsToggle, appsContent);
+    _initToggleSection(aboutToggle, aboutContent);
+    _initToggleSection(androidAppsToggle, androidAppsContent);
 }
 
 /**
@@ -65,20 +65,20 @@ function _initToggleSection(toggleButton, contentElement) {
     toggleButton.addEventListener('click', () => {
         const isExpanded = contentElement.classList.contains('open');
 
-        if (contentElement.id === 'moreContent' && appsContent && appsContent.classList.contains('open')) {
-            appsContent.classList.remove('open');
-            if (appsToggle) {
-                appsToggle.setAttribute('aria-expanded', 'false');
-                appsToggle.classList.remove('expanded');
+        if (contentElement.id === 'aboutContent' && androidAppsContent && androidAppsContent.classList.contains('open')) {
+            androidAppsContent.classList.remove('open');
+            if (androidAppsToggle) {
+                androidAppsToggle.setAttribute('aria-expanded', 'false');
+                androidAppsToggle.classList.remove('expanded');
             }
-            appsContent.setAttribute('aria-hidden', 'true');
-        } else if (contentElement.id === 'appsContent' && moreContent && moreContent.classList.contains('open')) {
-            moreContent.classList.remove('open');
-            if (moreToggle) {
-                moreToggle.setAttribute('aria-expanded', 'false');
-                moreToggle.classList.remove('expanded');
+            androidAppsContent.setAttribute('aria-hidden', 'true');
+        } else if (contentElement.id === 'androidAppsContent' && aboutContent && aboutContent.classList.contains('open')) {
+            aboutContent.classList.remove('open');
+            if (aboutToggle) {
+                aboutToggle.setAttribute('aria-expanded', 'false');
+                aboutToggle.classList.remove('expanded');
             }
-            moreContent.setAttribute('aria-hidden', 'true');
+            aboutContent.setAttribute('aria-hidden', 'true');
         }
 
         contentElement.classList.toggle('open', !isExpanded);

--- a/assets/js/router.js
+++ b/assets/js/router.js
@@ -83,6 +83,10 @@ async function loadPageContent(pageId, updateHistory = true) {
                 pagePath = 'pages/drawer/contact.html';
                 pageTitle = 'Contact';
                 break;
+            case 'about-me':
+                pagePath = 'pages/drawer/about-me.html';
+                pageTitle = 'About Me';
+                break;
             case 'ads-help-center':
                 pagePath = 'pages/drawer/more/apps/ads-help-center.html';
                 pageTitle = 'Ads Help Center';

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
     <div id="drawerOverlay" class="drawer-overlay"></div>
     <div id="pageLoadingOverlay" class="page-loading-overlay"><md-circular-progress indeterminate></md-circular-progress></div>
 
+    <nav aria-label="Main Navigation">
     <md-navigation-drawer id="navDrawer" class="navigation-drawer" pivot="start">
         <div class="drawer-header">
             <h2>Menu</h2>
@@ -56,45 +57,50 @@
                     <div slot="headline">Projects</div>
                 </md-list-item>
                 <md-divider></md-divider>
-                <md-list-item type="button" id="moreToggle" aria-controls="moreContent" aria-expanded="false">
-                    <md-icon slot="start"><span class="material-symbols-outlined">more_horiz</span></md-icon>
-                    <div slot="headline">More</div>
+                <md-list-item type="button" id="aboutToggle" aria-controls="aboutContent" aria-expanded="false">
+                    <md-icon slot="start"><span class="material-symbols-outlined">info</span></md-icon>
+                    <div slot="headline">About</div>
                     <md-icon slot="end"><span class="material-symbols-outlined">expand_more</span></md-icon>
                 </md-list-item>
-                <div class="nested-list" id="moreContent" role="group" aria-hidden="true">
+                <div class="nested-list" id="aboutContent" role="group" aria-hidden="true">
                     <md-list>
                         <md-list-item href="#contact" id="navContactLink">
                             <div slot="headline">Contact</div>
                         </md-list-item>
+                        <md-list-item href="#about-me" id="navAboutMeLink">
+                            <div slot="headline">About Me</div>
+                        </md-list-item>
                         <md-list-item href="#privacy-policy" id="navPrivacyPolicyLink">
-                            <div slot="headline">Privacy Policy</div>
+                            <div slot="headline">Privacy &amp; Cookies</div>
                         </md-list-item>
                         <md-list-item href="#code-of-conduct">
                             <div slot="headline">Code of Conduct</div>
                         </md-list-item>
                     </md-list>
                 </div>
-                <md-list-item type="button" id="appsToggle" aria-controls="appsContent" aria-expanded="false">
+                <md-divider></md-divider>
+                <md-list-item type="button" id="androidAppsToggle" aria-controls="androidAppsContent" aria-expanded="false">
                     <md-icon slot="start"><span class="material-symbols-outlined">apps</span></md-icon>
-                    <div slot="headline">Apps</div>
+                    <div slot="headline">Android Apps</div>
                     <md-icon slot="end"><span class="material-symbols-outlined">expand_more</span></md-icon>
                 </md-list-item>
-                <div class="nested-list" id="appsContent" role="group" aria-hidden="true">
+                <div class="nested-list" id="androidAppsContent" role="group" aria-hidden="true">
                     <md-list>
                          <md-list-item href="#ads-help-center" id="navAdsHelpCenterLink">
                             <div slot="headline">Ads Help Center</div>
                         </md-list-item>
                         <md-list-item href="#privacy-policy-end-user-software">
-                            <div slot="headline">Privacy Policy</div>
+                            <div slot="headline">App Privacy</div>
                         </md-list-item>
                         <md-list-item href="#terms-of-service-end-user-software">
                             <div slot="headline">Terms of Service</div>
                         </md-list-item>
                         <md-list-item href="#legal-notices" id="navLegalNoticesLink">
-                            <div slot="headline">Legal notices</div>
+                            <div slot="headline">Legal Info</div>
                         </md-list-item>
                     </md-list>
                 </div>
+                <md-divider></md-divider>
             </md-list>
         </div>
         <div class="drawer-footer">
@@ -110,8 +116,10 @@
                     <md-icon><span class="material-symbols-outlined">brightness_auto</span></md-icon>
                 </md-icon-button>
             </div>
+            <div class="text-center text-gray-500 text-sm mt-2">Privacy &amp; Cookies &bull; Code of Conduct</div>
         </div>
     </md-navigation-drawer>
+    </nav>
 
     <md-top-app-bar id="topAppBar">
         <md-icon-button id="menuButton" slot="navigationIcon" aria-label="Open menu">

--- a/pages/drawer/about-me.html
+++ b/pages/drawer/about-me.html
@@ -1,0 +1,4 @@
+<div id="aboutMePageContainer" class="page-section active">
+    <h1>About Me</h1>
+    <p>Hello! I'm Mihai-Cristian Condrea, an Android developer passionate about building delightful mobile experiences.</p>
+</div>


### PR DESCRIPTION
## Summary
- update navigation drawer structure
- rename menus to About and Android Apps
- add collapsible subsections with About Me link
- expose theme controls and legal info footer
- support new routes in navigation JS and router
- document new drawer layout in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688a13fb8bf4832db263e756f4dfc14c