### PR TITLE
Refactor router into helper modules

### DIFF
--- a/assets/js/router.js
+++ b/assets/js/router.js
@@ -1,5 +1,6 @@
 let pageContentArea, appBarHeadline;
 let initialHomepageHTML = '';
+const MINIMUM_LOAD_DURATION = 600;
 
 /**
  * Initializes the router with necessary DOM elements.
@@ -14,6 +15,25 @@ function initRouter(contentAreaEl, appBarHeadlineEl, homeHTML) {
     initialHomepageHTML = homeHTML;
 }
 
+function normalizePageId(pageId) {
+    if (typeof pageId !== 'string') {
+        return 'home';
+    }
+    let normalizedId = pageId;
+    if (normalizedId.startsWith('#')) {
+        normalizedId = normalizedId.substring(1);
+    }
+    if (normalizedId === '' || normalizedId === 'index.html') {
+        normalizedId = 'home';
+    }
+    return normalizedId;
+}
+
+function createGenericErrorHtml(message) {
+    const finalMessage = message || 'Failed to load page. An unknown error occurred.';
+    return `<div class="page-section active"><p class="error-message text-red-500">${finalMessage}</p></div>`;
+}
+
 /**
  * Loads content for a given pageId into the main content area.
  * @param {string} pageId - The ID of the page to load (e.g., 'home', 'privacy-policy').
@@ -24,172 +44,92 @@ async function loadPageContent(pageId, updateHistory = true) {
     if (typeof showPageLoadingOverlay === "function") showPageLoadingOverlay();
     if (typeof closeDrawer === 'function') closeDrawer();
 
-    if (pageContentArea && pageContentArea.animate) {
-        try {
-            await pageContentArea.animate(
-                [{ opacity: 1 }, { opacity: 0 }],
-                {
-                    duration: 90,
-                    easing: 'cubic-bezier(0.4, 0, 1, 1)',
-                    fill: 'forwards'
-                }
-            ).finished;
-        } catch (e) {
-            // Ignore animation errors
-        }
-        pageContentArea.style.opacity = 0;
-    }
-
-    let pageTitle = "Mihai's Profile";
-    let newUrlFragment = 'home';
-    let pagePath = '';
-
     if (!pageContentArea) {
         console.error("Router: pageContentArea element not set. Call initRouter first.");
+        if (typeof hidePageLoadingOverlay === 'function') hidePageLoadingOverlay();
         return;
     }
 
-    if (pageId.startsWith('#')) {
-        pageId = pageId.substring(1);
-    }
-    if (pageId === '' || pageId === 'index.html') {
-        pageId = 'home';
-    }
-    newUrlFragment = pageId;
+    const normalizedPageId = normalizePageId(pageId);
+    const newUrlFragment = normalizedPageId;
 
-    let errorContent = `<div class="page-section active"><p class="error-message text-red-500">Failed to load page. An unknown error occurred.</p></div>`;
+    const animationHelper = typeof RouterAnimation !== 'undefined' ? RouterAnimation : null;
+    const contentLoader = typeof RouterContentLoader !== 'undefined' ? RouterContentLoader : null;
+    const historyHelper = typeof RouterHistory !== 'undefined' ? RouterHistory : null;
 
-    if (pageId === 'home') {
-        pageContentArea.innerHTML = initialHomepageHTML;
-        pageTitle = "Mihai's Profile";
-        if (typeof fetchBlogPosts === 'function' && document.getElementById('newsGrid')) {
-            fetchBlogPosts();
+    if (animationHelper && typeof animationHelper.fadeOut === 'function') {
+        await animationHelper.fadeOut(pageContentArea);
+    } else if (pageContentArea.style) {
+        pageContentArea.style.opacity = 0;
+    }
+
+    let loadResult;
+    if (contentLoader && typeof contentLoader.fetchPageMarkup === 'function') {
+        try {
+            loadResult = await contentLoader.fetchPageMarkup(normalizedPageId, {
+                initialHomeHTML: initialHomepageHTML
+            });
+        } catch (error) {
+            loadResult = {
+                status: 'error',
+                title: 'Error',
+                html: createGenericErrorHtml(`Failed to load page. ${error.message}`),
+                error
+            };
         }
     } else {
-        switch (pageId) {
-            case 'privacy-policy':
-                pagePath = 'pages/drawer/more/privacy-policy.html';
-                pageTitle = 'Privacy Policy';
-                break;
-            case 'songs':
-                pagePath = 'pages/drawer/songs.html';
-                pageTitle = 'My Music';
-                break;
-            case 'projects':
-                pagePath = 'pages/drawer/projects.html';
-                pageTitle = 'Projects';
-                break;
-            case 'contact':
-                pagePath = 'pages/drawer/contact.html';
-                pageTitle = 'Contact';
-                break;
-            case 'about-me':
-                pagePath = 'pages/drawer/about-me.html';
-                pageTitle = 'About Me';
-                break;
-            case 'ads-help-center':
-                pagePath = 'pages/drawer/more/apps/ads-help-center.html';
-                pageTitle = 'Ads Help Center';
-                break;
-            case 'legal-notices':
-                pagePath = 'pages/drawer/more/apps/legal-notices.html';
-                pageTitle = 'Legal Notices';
-                break;
-            case 'code-of-conduct':
-                pagePath = 'pages/drawer/more/code-of-conduct.html';
-                pageTitle = 'Code of Conduct';
-                break;
-            case 'privacy-policy-end-user-software':
-                pagePath = 'pages/drawer/more/apps/privacy-policy-apps.html';
-                pageTitle = 'Privacy Policy – End-User Software';
-                break;
-            case 'terms-of-service-end-user-software':
-                pagePath = 'pages/drawer/more/apps/terms-of-service-apps.html';
-                pageTitle = 'Terms of Service – End-User Software';
-                break;
-            case 'resume':
-                pagePath = 'pages/resume/resume.html';
-                pageTitle = "Mihai's Resume";
-                break;
+        loadResult = {
+            status: 'error',
+            title: 'Error',
+            html: createGenericErrorHtml('Failed to load page. Router content loader is unavailable.')
+        };
+    }
 
-            default:
-                console.warn('Router: Unknown page:', pageId);
-                pageContentArea.innerHTML = `<div class="page-section active"><p>Page not found: ${pageId}</p></div>`;
-                pageTitle = 'Not Found';
-                if (appBarHeadline) appBarHeadline.textContent = pageTitle;
-                document.title = pageTitle + " - Mihai's Profile";
-                if (updateHistory && window.history.pushState) {
-                     window.history.pushState({ page: pageId }, pageTitle, `#${newUrlFragment}`);
-                }
-                window.scrollTo(0, 0);
-                updateActiveNavLink(newUrlFragment);
-                if (pageContentArea && pageContentArea.animate) {
-                    try {
-                        await pageContentArea.animate(
-                            [{ opacity: 0 }, { opacity: 1 }],
-                            {
-                                duration: 210,
-                                easing: 'cubic-bezier(0, 0, 0.2, 1)',
-                                fill: 'forwards'
-                            }
-                        ).finished;
-                    } catch (e) {
-                        // Ignore animation errors
-                    }
-                    pageContentArea.style.opacity = 1;
-                }
-                return;
-        }
+    if (loadResult.status === 'not-found') {
+        console.warn('Router: Unknown page:', normalizedPageId);
+    }
 
+    if (loadResult.status === 'error' && loadResult.error) {
+        const contextTitle = loadResult.sourceTitle || loadResult.title || normalizedPageId;
+        console.error(`Error loading ${contextTitle}:`, loadResult.error);
+    }
+
+    pageContentArea.innerHTML = typeof loadResult.html === 'string' ? loadResult.html : createGenericErrorHtml();
+
+    if (typeof loadResult.onReady === 'function') {
         try {
-            const response = await fetch(pagePath);
-            if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status} for ${pagePath}`);
-            }
-            const contentHTML = await response.text();
-            pageContentArea.innerHTML = contentHTML;
-            if (pageId === 'songs' && typeof loadSongs === 'function' && document.getElementById('songsGrid')) {
-                loadSongs();
-            } else if (pageId === 'resume' && typeof initResumePage === 'function') {
-                initResumePage();
-            } else if (pageId === 'projects' && typeof initProjectsPage === 'function') {
-                initProjectsPage();
-            }
+            loadResult.onReady();
         } catch (error) {
-            console.error(`Error loading ${pageTitle}:`, error);
-            errorContent = `<div class="page-section active"><p class="error-message text-red-500">Failed to load page: ${pageTitle}. ${error.message}</p></div>`;
-            pageContentArea.innerHTML = errorContent;
-            pageTitle = 'Error';
+            console.error('Router: Error running page ready hook:', error);
         }
     }
 
-    if (appBarHeadline) appBarHeadline.textContent = pageTitle;
-    document.title = pageTitle + " - Mihai's Profile";
+    const pageTitle = loadResult.title || (contentLoader && contentLoader.DEFAULT_PAGE_TITLE) || "Mihai's Profile";
 
-    if (updateHistory && window.history.pushState) {
-        window.history.pushState({ page: pageId }, pageTitle, `#${newUrlFragment}`);
+    if (historyHelper && typeof historyHelper.updateTitle === 'function') {
+        historyHelper.updateTitle(appBarHeadline, pageTitle);
+    } else {
+        if (appBarHeadline) appBarHeadline.textContent = pageTitle;
+        document.title = `${pageTitle} - Mihai's Profile`;
     }
+
+    if (historyHelper && typeof historyHelper.pushState === 'function') {
+        historyHelper.pushState(normalizedPageId, pageTitle, newUrlFragment, updateHistory);
+    } else if (updateHistory && window.history && typeof window.history.pushState === 'function') {
+        window.history.pushState({ page: normalizedPageId }, pageTitle, `#${newUrlFragment}`);
+    }
+
     window.scrollTo(0, 0);
     updateActiveNavLink(newUrlFragment);
 
-    if (pageContentArea && pageContentArea.animate) {
-        try {
-            await pageContentArea.animate(
-                [{ opacity: 0 }, { opacity: 1 }],
-                {
-                    duration: 210,
-                    easing: 'cubic-bezier(0, 0, 0.2, 1)',
-                    fill: 'forwards'
-                }
-            ).finished;
-        } catch (e) {
-            // Ignore animation errors
-        }
+    if (animationHelper && typeof animationHelper.fadeIn === 'function') {
+        await animationHelper.fadeIn(pageContentArea);
+    } else if (pageContentArea.style) {
         pageContentArea.style.opacity = 1;
     }
+
     const elapsed = Date.now() - loadStart;
-    const minDuration = 600;
-    await new Promise(r => setTimeout(r, Math.max(0, minDuration - elapsed)));
+    await new Promise(r => setTimeout(r, Math.max(0, MINIMUM_LOAD_DURATION - elapsed)));
     if (typeof hidePageLoadingOverlay === 'function') hidePageLoadingOverlay();
 }
 
@@ -198,12 +138,7 @@ async function loadPageContent(pageId, updateHistory = true) {
  * @param {string} currentPageId - The ID of the currently active page.
  */
 function updateActiveNavLink(currentPageId) {
-    if (currentPageId.startsWith('#')) {
-        currentPageId = currentPageId.substring(1);
-    }
-    if (currentPageId === '' || currentPageId === 'index.html') {
-        currentPageId = 'home';
-    }
+    const normalizedCurrentPage = normalizePageId(currentPageId);
 
     document.querySelectorAll('#navDrawer md-list-item[href]').forEach(item => {
         item.classList.remove('nav-item-active');
@@ -217,8 +152,8 @@ function updateActiveNavLink(currentPageId) {
 
         let itemHref = item.getAttribute('href');
         if (itemHref) {
-            itemHref = itemHref.startsWith('#') ? itemHref.substring(1) : itemHref;
-            if (itemHref === currentPageId) {
+            const normalizedHref = normalizePageId(itemHref);
+            if (normalizedHref === normalizedCurrentPage) {
                 item.classList.add('nav-item-active');
                  if (typeof item.active === 'boolean') item.active = true;
 

--- a/assets/js/router/animation.js
+++ b/assets/js/router/animation.js
@@ -1,0 +1,69 @@
+(function (global) {
+    const defaultFadeOutTiming = {
+        duration: 90,
+        easing: 'cubic-bezier(0.4, 0, 1, 1)',
+        fill: 'forwards'
+    };
+
+    const defaultFadeInTiming = {
+        duration: 210,
+        easing: 'cubic-bezier(0, 0, 0.2, 1)',
+        fill: 'forwards'
+    };
+
+    function setFinalOpacity(element, value) {
+        if (element && element.style) {
+            element.style.opacity = value;
+        }
+    }
+
+    function performFade(element, keyframes, defaultTiming, overrides, finalOpacity) {
+        if (!element) {
+            return Promise.resolve();
+        }
+
+        const timing = Object.assign({}, defaultTiming, overrides || {});
+
+        if (typeof element.animate !== 'function') {
+            setFinalOpacity(element, finalOpacity);
+            return Promise.resolve();
+        }
+
+        try {
+            const animation = element.animate(keyframes, timing);
+            return animation.finished
+                .catch(() => { })
+                .finally(() => {
+                    setFinalOpacity(element, finalOpacity);
+                });
+        } catch (error) {
+            setFinalOpacity(element, finalOpacity);
+            return Promise.resolve();
+        }
+    }
+
+    function fadeOut(element, timingOverrides) {
+        return performFade(
+            element,
+            [{ opacity: 1 }, { opacity: 0 }],
+            defaultFadeOutTiming,
+            timingOverrides,
+            0
+        );
+    }
+
+    function fadeIn(element, timingOverrides) {
+        return performFade(
+            element,
+            [{ opacity: 0 }, { opacity: 1 }],
+            defaultFadeInTiming,
+            timingOverrides,
+            1
+        );
+    }
+
+    global.RouterAnimation = {
+        fadeIn,
+        fadeOut
+    };
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/assets/js/router/contentLoader.js
+++ b/assets/js/router/contentLoader.js
@@ -1,0 +1,136 @@
+(function (global) {
+    const DEFAULT_PAGE_TITLE = "Mihai's Profile";
+
+    const PAGE_CONFIG = {
+        'privacy-policy': {
+            path: 'pages/drawer/more/privacy-policy.html',
+            title: 'Privacy Policy'
+        },
+        'songs': {
+            path: 'pages/drawer/songs.html',
+            title: 'My Music',
+            onReady: () => {
+                if (
+                    typeof loadSongs === 'function' &&
+                    typeof document !== 'undefined' &&
+                    document.getElementById('songsGrid')
+                ) {
+                    loadSongs();
+                }
+            }
+        },
+        'projects': {
+            path: 'pages/drawer/projects.html',
+            title: 'Projects',
+            onReady: () => {
+                if (typeof initProjectsPage === 'function') {
+                    initProjectsPage();
+                }
+            }
+        },
+        'contact': {
+            path: 'pages/drawer/contact.html',
+            title: 'Contact'
+        },
+        'about-me': {
+            path: 'pages/drawer/about-me.html',
+            title: 'About Me'
+        },
+        'ads-help-center': {
+            path: 'pages/drawer/more/apps/ads-help-center.html',
+            title: 'Ads Help Center'
+        },
+        'legal-notices': {
+            path: 'pages/drawer/more/apps/legal-notices.html',
+            title: 'Legal Notices'
+        },
+        'code-of-conduct': {
+            path: 'pages/drawer/more/code-of-conduct.html',
+            title: 'Code of Conduct'
+        },
+        'privacy-policy-end-user-software': {
+            path: 'pages/drawer/more/apps/privacy-policy-apps.html',
+            title: 'Privacy Policy – End-User Software'
+        },
+        'terms-of-service-end-user-software': {
+            path: 'pages/drawer/more/apps/terms-of-service-apps.html',
+            title: 'Terms of Service – End-User Software'
+        },
+        'resume': {
+            path: 'pages/resume/resume.html',
+            title: "Mihai's Resume",
+            onReady: () => {
+                if (typeof initResumePage === 'function') {
+                    initResumePage();
+                }
+            }
+        }
+    };
+
+    function createErrorHtml(message) {
+        return `<div class="page-section active"><p class="error-message text-red-500">${message}</p></div>`;
+    }
+
+    function createNotFoundHtml(pageId) {
+        return `<div class="page-section active"><p>Page not found: ${pageId}</p></div>`;
+    }
+
+    function runHomeReadyHook() {
+        if (
+            typeof fetchBlogPosts === 'function' &&
+            typeof document !== 'undefined' &&
+            document.getElementById('newsGrid')
+        ) {
+            fetchBlogPosts();
+        }
+    }
+
+    async function fetchPageMarkup(pageId, options = {}) {
+        if (pageId === 'home') {
+            return {
+                status: 'success',
+                title: DEFAULT_PAGE_TITLE,
+                html: options.initialHomeHTML || '',
+                onReady: runHomeReadyHook,
+                sourceTitle: DEFAULT_PAGE_TITLE
+            };
+        }
+
+        const pageConfig = PAGE_CONFIG[pageId];
+        if (!pageConfig) {
+            return {
+                status: 'not-found',
+                title: 'Not Found',
+                html: createNotFoundHtml(pageId)
+            };
+        }
+
+        try {
+            const response = await fetch(pageConfig.path);
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status} for ${pageConfig.path}`);
+            }
+            const html = await response.text();
+            return {
+                status: 'success',
+                title: pageConfig.title,
+                html,
+                onReady: pageConfig.onReady || null,
+                sourceTitle: pageConfig.title
+            };
+        } catch (error) {
+            return {
+                status: 'error',
+                title: 'Error',
+                html: createErrorHtml(`Failed to load page: ${pageConfig.title}. ${error.message}`),
+                error,
+                sourceTitle: pageConfig.title
+            };
+        }
+    }
+
+    global.RouterContentLoader = {
+        fetchPageMarkup,
+        DEFAULT_PAGE_TITLE
+    };
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/assets/js/router/history.js
+++ b/assets/js/router/history.js
@@ -1,0 +1,25 @@
+(function (global) {
+    const DOCUMENT_TITLE_SUFFIX = " - Mihai's Profile";
+
+    function updateTitle(appBarHeadline, pageTitle) {
+        if (appBarHeadline) {
+            appBarHeadline.textContent = pageTitle;
+        }
+        if (typeof document !== 'undefined') {
+            document.title = `${pageTitle}${DOCUMENT_TITLE_SUFFIX}`;
+        }
+    }
+
+    function pushState(pageId, pageTitle, urlFragment, shouldUpdate = true) {
+        if (!shouldUpdate || !global.history || typeof global.history.pushState !== 'function') {
+            return;
+        }
+        global.history.pushState({ page: pageId }, pageTitle, `#${urlFragment}`);
+    }
+
+    global.RouterHistory = {
+        DOCUMENT_TITLE_SUFFIX,
+        updateTitle,
+        pushState
+    };
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/index.html
+++ b/index.html
@@ -259,6 +259,9 @@
     <script src="assets/js/resume.js" defer></script>
     <script src="assets/js/songs.js" defer></script>
     <script src="assets/js/projects.js" defer></script>
+    <script src="assets/js/router/animation.js" defer></script>
+    <script src="assets/js/router/contentLoader.js" defer></script>
+    <script src="assets/js/router/history.js" defer></script>
     <script src="assets/js/router.js" defer></script>
     <script src="assets/js/app.js" defer></script>
 


### PR DESCRIPTION
## Summary
- add router-specific helpers that handle fade animations, remote page fetching, and history/title updates
- refactor `loadPageContent` to orchestrate helper calls while keeping navigation link highlighting logic
- register the helper scripts in `index.html` so they load before the router

## Testing
- Manual SPA navigation via Playwright script to verify fades, content loads, and history updates

------
https://chatgpt.com/codex/tasks/task_e_68ca6e26e16c832d93489935f85c1741