### PR TITLE
Add GitHub committers ranking card

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -122,6 +122,95 @@ md-assist-chip {
   --md-assist-chip-label-text-font: 'Poppins', sans-serif;
 }
 
+/* --- Achievement Card --- */
+md-filled-card.achievement-card {
+  --md-filled-card-container-color: var(--app-card-bg-color);
+  background-color: var(--app-card-bg-color);
+  border-radius: 16px;
+  padding: 1.5rem;
+  margin-bottom: 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.achievement-card .achievement-body {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.achievement-card .achievement-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--md-sys-color-primary-container);
+  color: var(--md-sys-color-on-primary-container);
+  flex-shrink: 0;
+}
+
+.achievement-card .achievement-icon .material-symbols-outlined {
+  font-size: 32px;
+}
+
+.achievement-card .achievement-content {
+  flex: 1 1 220px;
+  min-width: 0;
+  color: var(--app-text-color);
+}
+
+.achievement-card .achievement-content h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.3rem;
+  font-weight: 500;
+  color: var(--app-text-color);
+}
+
+.achievement-card .achievement-rank {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 600;
+  color: var(--md-sys-color-primary);
+  line-height: 1.2;
+}
+
+.achievement-card .achievement-status {
+  margin: 0.5rem 0 0;
+  color: var(--app-secondary-text-color);
+  line-height: 1.5;
+}
+
+.achievement-card .achievement-status.error {
+  color: var(--md-sys-color-error);
+}
+
+.achievement-card .achievement-updated {
+  margin: 0.5rem 0 0;
+  font-size: 0.9rem;
+  color: var(--app-secondary-text-color);
+}
+
+.achievement-card .achievement-actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.achievement-card .achievement-actions a {
+  text-decoration: none;
+}
+
+@media (max-width: 600px) {
+  .achievement-card .achievement-body {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
 /* --- General Card Actions --- */
 .card-actions {
   padding: 1rem 1.5rem;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -73,11 +73,22 @@ function buildRouterOptions() {
         };
     }
 
-    if (typeof fetchBlogPosts === 'function') {
+    if (typeof fetchBlogPosts === 'function' || typeof fetchCommittersRanking === 'function') {
         options.onHomeLoad = () => {
-            const newsGrid = document.getElementById('newsGrid');
-            if (newsGrid) {
-                fetchBlogPosts();
+            if (typeof fetchBlogPosts === 'function') {
+                const newsGrid = document.getElementById('newsGrid');
+                if (newsGrid) {
+                    fetchBlogPosts();
+                }
+            }
+
+            if (typeof fetchCommittersRanking === 'function') {
+                const rankingCardPresent = document.getElementById('committers-rank')
+                    || document.getElementById('committers-status')
+                    || document.querySelector('.achievement-card');
+                if (rankingCardPresent) {
+                    fetchCommittersRanking();
+                }
             }
         };
     }

--- a/assets/js/committers.js
+++ b/assets/js/committers.js
@@ -1,0 +1,122 @@
+const COMMITTERS_RANKING_URL = 'https://committers.top/rank_only/romania.json';
+const COMMITTERS_USERNAME = 'MihaiCristianCondrea';
+const COMMITTERS_UPDATED_FALLBACK = 'Last updated: —';
+
+function formatOrdinal(value) {
+    const absValue = Math.abs(Number(value));
+    if (!Number.isFinite(absValue)) {
+        return `${value}`;
+    }
+    const mod100 = absValue % 100;
+    if (mod100 >= 11 && mod100 <= 13) {
+        return `${value}th`;
+    }
+    switch (absValue % 10) {
+        case 1:
+            return `${value}st`;
+        case 2:
+            return `${value}nd`;
+        case 3:
+            return `${value}rd`;
+        default:
+            return `${value}th`;
+    }
+}
+
+function formatDataAsOf(rawValue) {
+    if (typeof rawValue !== 'string') {
+        return null;
+    }
+
+    const trimmed = rawValue.trim();
+    if (!trimmed) {
+        return null;
+    }
+
+    const match = trimmed.match(/^(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2}:\d{2})\s+([+-]\d{2})(\d{2})$/);
+    if (match) {
+        const [, datePart, timePart, tzHour, tzMinute] = match;
+        const isoCandidate = `${datePart}T${timePart}${tzHour}:${tzMinute}`;
+        const parsed = new Date(isoCandidate);
+        if (!Number.isNaN(parsed.getTime())) {
+            return parsed.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+        }
+    }
+
+    const fallbackParsed = new Date(trimmed);
+    if (!Number.isNaN(fallbackParsed.getTime())) {
+        return fallbackParsed.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+    }
+
+    return trimmed;
+}
+
+function updateCommittersStatus(statusElement, message, isError = false) {
+    if (!statusElement) {
+        return;
+    }
+    statusElement.textContent = message;
+    statusElement.classList.toggle('error', Boolean(isError));
+}
+
+async function fetchCommittersRanking() {
+    const rankElement = typeof getDynamicElement === 'function'
+        ? getDynamicElement('committers-rank')
+        : document.getElementById('committers-rank');
+    const statusElement = typeof getDynamicElement === 'function'
+        ? getDynamicElement('committers-status')
+        : document.getElementById('committers-status');
+    const updatedElement = typeof getDynamicElement === 'function'
+        ? getDynamicElement('committers-updated')
+        : document.getElementById('committers-updated');
+
+    if (!rankElement || !statusElement) {
+        return;
+    }
+
+    const defaultRankText = '—';
+    rankElement.textContent = defaultRankText;
+    updateCommittersStatus(statusElement, 'Checking latest ranking...', false);
+    if (updatedElement) {
+        updatedElement.textContent = COMMITTERS_UPDATED_FALLBACK;
+    }
+
+    try {
+        const response = await fetch(COMMITTERS_RANKING_URL, {
+            headers: {
+                'Accept': 'application/json'
+            },
+            cache: 'no-store'
+        });
+
+        if (!response.ok) {
+            throw new Error(`Network response was not ok (status ${response.status})`);
+        }
+
+        const data = await response.json();
+        const users = Array.isArray(data?.user) ? data.user : [];
+        const userIndex = users.findIndex((username) => username === COMMITTERS_USERNAME);
+
+        if (userIndex === -1) {
+            updateCommittersStatus(statusElement, 'Mihai-Cristian Condrea is not listed in the current ranking.', true);
+            return;
+        }
+
+        const rank = userIndex + 1;
+        rankElement.textContent = `#${rank.toLocaleString(undefined)}`;
+        updateCommittersStatus(statusElement, `Mihai-Cristian Condrea is currently ${formatOrdinal(rank)} in Romania's GitHub committers leaderboard.`, false);
+
+        if (updatedElement) {
+            const formattedTimestamp = formatDataAsOf(data?.data_asof);
+            updatedElement.textContent = formattedTimestamp
+                ? `Last updated: ${formattedTimestamp}`
+                : COMMITTERS_UPDATED_FALLBACK;
+        }
+    } catch (error) {
+        console.error('Committers ranking error:', error);
+        updateCommittersStatus(statusElement, 'Ranking data is unavailable right now. Please try again later.', true);
+        if (updatedElement) {
+            updatedElement.textContent = COMMITTERS_UPDATED_FALLBACK;
+        }
+    }
+}

--- a/index.html
+++ b/index.html
@@ -183,6 +183,30 @@
                 <iframe style="border-radius:12px" src="https://open.spotify.com/embed/show/1kfFn7caL2U2wlhaD9IMIa?utm_source=generator" width="100%" height="152" frameBorder="0" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
             </div>
 
+            <md-filled-card class="achievement-card">
+                <div class="achievement-body">
+                    <div class="achievement-icon" aria-hidden="true">
+                        <span class="material-symbols-outlined">military_tech</span>
+                    </div>
+                    <div class="achievement-content">
+                        <h3>GitHub Committers Ranking</h3>
+                        <p class="achievement-rank" id="committers-rank">—</p>
+                        <p class="achievement-status" id="committers-status" role="status" aria-live="polite">
+                            Checking latest ranking...
+                        </p>
+                        <p class="achievement-updated" id="committers-updated">Last updated: —</p>
+                    </div>
+                </div>
+                <div class="achievement-actions">
+                    <a href="https://committers.top/romania" target="_blank" rel="noopener noreferrer">
+                        <md-text-button>
+                            <md-icon slot="icon">open_in_new</md-icon>
+                            View ranking
+                        </md-text-button>
+                    </a>
+                </div>
+            </md-filled-card>
+
             <h2 class="page-section-title">Latest news</h2>
             <div class="news-section">
                 <div class="news-grid" id="newsGrid">
@@ -264,6 +288,7 @@
     <script src="assets/js/router/contentLoader.js" defer></script>
     <script src="assets/js/router/history.js" defer></script>
     <script src="assets/js/router.js" defer></script>
+    <script src="assets/js/committers.js" defer></script>
     <script src="assets/js/app.js" defer></script>
 
 </body>


### PR DESCRIPTION
## Summary
- add an achievement card on the home page that highlights Mihai-Cristian Condrea's GitHub committers ranking
- implement styling and a data-fetching helper so the card matches the existing layout and shows live ranking details
- load the committers ranking script when the home page is displayed alongside the existing blog feed logic

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cd11244574832d83d0ba3b954b228c