### PR TITLE
Adjust home hero and ranking cards layout

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -55,9 +55,9 @@ md-filled-card.profile-card {
   width: 100%;
   background-color: var(--app-card-bg-color);
   --md-filled-card-container-color: var(--app-card-bg-color);
-  border-radius: 16px;
+  border-radius: 16px 16px 4px 4px;
   overflow: hidden;
-  margin-bottom: 2.5rem;
+  margin-bottom: 2px;
   transition: background-color 0.3s ease;
 }
 
@@ -126,9 +126,9 @@ md-assist-chip {
 md-filled-card.achievement-card {
   --md-filled-card-container-color: var(--app-card-bg-color);
   background-color: var(--app-card-bg-color);
-  border-radius: 16px;
+  border-radius: 4px 4px 16px 16px;
   padding: 1.5rem;
-  margin-bottom: 2.5rem;
+  margin-bottom: 0;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
@@ -728,12 +728,17 @@ md-filled-card.profile-card {
 }
 
 .profile-card-actions {
-  padding: 0.75rem 1.5rem 1.5rem 1.5rem; 
+  padding: 0.75rem 1.5rem 1.5rem 1.5rem;
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  border-top: 1px solid var(--app-border-color); 
   margin-top: auto;
+}
+
+md-divider.profile-section-divider {
+  --md-divider-thickness: 1px;
+  --md-divider-color: var(--app-border-color);
+  margin: 1.5rem 0 1.5rem;
 }
 
 .profile-card-actions a {

--- a/index.html
+++ b/index.html
@@ -162,21 +162,6 @@
                     </md-chip-set>
                 </div>
             </md-filled-card>
-            
-            <div class="profile-card-actions">
-                <a href="https://play.google.com/store/apps/dev?id=5390214922640123642" target="_blank" rel="noopener noreferrer">
-                    <md-outlined-button>
-                        <md-icon slot="icon"><i class="fab fa-google-play"></i></md-icon>
-                        My Apps on Google Play
-                    </md-outlined-button>
-                </a>
-                <a href="https://g.dev/Mihai-Cristian-Condrea" target="_blank" rel="noopener noreferrer">
-                    <md-outlined-button>
-                        <md-icon slot="icon"><span class="material-symbols-outlined">code_blocks</span></md-icon>
-                        Google Developer Profile
-                    </md-outlined-button>
-                </a>
-            </div>
 
             <md-filled-card class="achievement-card">
                 <div class="achievement-body">
@@ -201,6 +186,23 @@
                     </a>
                 </div>
             </md-filled-card>
+
+            <md-divider class="profile-section-divider"></md-divider>
+
+            <div class="profile-card-actions">
+                <a href="https://play.google.com/store/apps/dev?id=5390214922640123642" target="_blank" rel="noopener noreferrer">
+                    <md-outlined-button>
+                        <md-icon slot="icon"><i class="fab fa-google-play"></i></md-icon>
+                        My Apps on Google Play
+                    </md-outlined-button>
+                </a>
+                <a href="https://g.dev/Mihai-Cristian-Condrea" target="_blank" rel="noopener noreferrer">
+                    <md-outlined-button>
+                        <md-icon slot="icon"><span class="material-symbols-outlined">code_blocks</span></md-icon>
+                        Google Developer Profile
+                    </md-outlined-button>
+                </a>
+            </div>
 
             <div class="podcast-embed">
                 <h2 class="page-section-title">By Design Podcast</h2>


### PR DESCRIPTION
## Summary
- stack the profile and GitHub ranking cards together with the requested divider and action layout
- tweak card border radii and spacing to match the new 4dp styling for adjoining corners
- add a dedicated divider style for the profile action buttons section

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd148d2090832dbf9db35f6c78a928