### PR TITLE
Add numbered privacy section badges to legal pages

### DIFF
--- a/assets/css/pages.css
+++ b/assets/css/pages.css
@@ -867,6 +867,75 @@
     margin-bottom: 0;
 }
 
+/* Shared legal page heading numbering */
+#privacyPolicyPageContainer,
+#legalNoticesPageContainer,
+#adsHelpCenterPageContainer,
+#privacyPolicyAppsPageContainer,
+#termsOfServiceAppsPageContainer,
+#codeOfConductPageContainer {
+  counter-reset: privacySections;
+}
+
+#privacyPolicyPageContainer h2,
+#legalNoticesPageContainer h2,
+#adsHelpCenterPageContainer h2,
+#privacyPolicyAppsPageContainer h2,
+#termsOfServiceAppsPageContainer h2,
+#codeOfConductPageContainer h2 {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  line-height: 1.35;
+  flex-wrap: wrap;
+}
+
+#privacyPolicyPageContainer h2::before,
+#legalNoticesPageContainer h2::before,
+#adsHelpCenterPageContainer h2::before,
+#privacyPolicyAppsPageContainer h2::before,
+#termsOfServiceAppsPageContainer h2::before,
+#codeOfConductPageContainer h2::before {
+  counter-increment: privacySections;
+  content: url('../icons/privacy-section.svg') / "Section " counter(privacySections);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  flex-shrink: 0;
+  border-radius: 999px;
+  border: 1px solid var(--app-border-color);
+  background-color: var(--md-sys-color-surface-container-high);
+  padding: 0.35rem;
+  margin-top: 0.1rem;
+  color: var(--md-sys-color-primary);
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
+  box-sizing: border-box;
+}
+
+@media (max-width: 600px) {
+  #privacyPolicyPageContainer h2,
+  #legalNoticesPageContainer h2,
+  #adsHelpCenterPageContainer h2,
+  #privacyPolicyAppsPageContainer h2,
+  #termsOfServiceAppsPageContainer h2,
+  #codeOfConductPageContainer h2 {
+    gap: 0.6rem;
+  }
+
+  #privacyPolicyPageContainer h2::before,
+  #legalNoticesPageContainer h2::before,
+  #adsHelpCenterPageContainer h2::before,
+  #privacyPolicyAppsPageContainer h2::before,
+  #termsOfServiceAppsPageContainer h2::before,
+  #codeOfConductPageContainer h2::before {
+    width: 2.1rem;
+    height: 2.1rem;
+    padding: 0.25rem;
+  }
+}
+
 /* --- Contact Page Specific Styles --- */
 #contactPageContainer {
   background-color: var(--md-sys-color-surface-container-high);

--- a/assets/icons/privacy-section.svg
+++ b/assets/icons/privacy-section.svg
@@ -1,0 +1,6 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="16" cy="16" r="13" fill="currentColor" fill-opacity="0.12"/>
+  <circle cx="16" cy="16" r="13" stroke="currentColor" stroke-opacity="0.45" stroke-width="2"/>
+  <path d="M16 8.5L22 11.1V15.5C22 19.44 19.14 22.96 16 24.92C12.86 22.96 10 19.44 10 15.5V11.1L16 8.5Z" fill="currentColor" fill-opacity="0.65"/>
+  <path d="M19.58 14.42L15.41 18.59L13.41 16.58L14.55 15.44L15.41 16.3L18.44 13.27L19.58 14.42Z" fill="currentColor"/>
+</svg>


### PR DESCRIPTION
## Summary
- add counter-based numbering and badge styling to legal page headings
- create a reusable privacy section icon asset and responsive spacing adjustments for the badges

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdb1f56d24832d817ee403968be3c0