### PR TITLE
Switch typography to Google Sans

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1,5 +1,5 @@
 body {
-  font-family: 'JYMPDD+ProductSans-Regular', 'Poppins', sans-serif;
+  font-family: 'Google Sans Regular', 'Poppins', sans-serif;
   background-color: var(--app-bg-color);
   color: var(--app-text-color);
   margin: 0;

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -135,7 +135,7 @@ md-chip-set {
 md-assist-chip {
   margin-right: 0.5rem;
   margin-bottom: 0.5rem;
-  --md-assist-chip-label-text-font: 'JYMPDD+ProductSans-Regular',
+  --md-assist-chip-label-text-font: 'Google Sans Regular',
     'Poppins', sans-serif;
 }
 
@@ -648,7 +648,7 @@ md-list-item {
   --md-list-item-supporting-text-color: var(--app-secondary-text-color);
   --md-list-item-leading-icon-color: var(--app-text-color);
   --md-list-item-trailing-icon-color: var(--app-text-color);
-  --md-list-item-label-text-font: 'JYMPDD+ProductSans-Regular',
+  --md-list-item-label-text-font: 'Google Sans Regular',
     'Poppins', sans-serif;
 }
 
@@ -669,7 +669,7 @@ md-list-item {
   --md-list-item-supporting-text-color: var(--md-sys-color-on-surface-variant);
   --md-list-item-leading-icon-color: var(--md-sys-color-on-surface-variant);
   --md-list-item-trailing-icon-color: var(--md-sys-color-on-surface-variant);
-  --md-list-item-label-text-font: 'JYMPDD+ProductSans-Regular',
+  --md-list-item-label-text-font: 'Google Sans Regular',
     'Poppins', sans-serif;
   --md-list-item-leading-space: 16px;
   --md-list-item-trailing-space: 16px;

--- a/assets/css/fonts.css
+++ b/assets/css/fonts.css
@@ -1,16 +1,16 @@
 @font-face {
-  font-family: 'JYMPDD+ProductSans-Regular';
-  src: url('https://db.onlinewebfonts.com/t/ab0f2f4d22ea179f449ca6a60f5e599c.eot');
+  font-family: 'Google Sans Regular';
+  src: url('https://db.onlinewebfonts.com/t/000be6a5acfcd4e4a425e9f1bb6c80f0.eot');
   src:
-    url('https://db.onlinewebfonts.com/t/ab0f2f4d22ea179f449ca6a60f5e599c.eot?#iefix')
+    url('https://db.onlinewebfonts.com/t/000be6a5acfcd4e4a425e9f1bb6c80f0.eot?#iefix')
       format('embedded-opentype'),
-    url('https://db.onlinewebfonts.com/t/ab0f2f4d22ea179f449ca6a60f5e599c.woff2')
+    url('https://db.onlinewebfonts.com/t/000be6a5acfcd4e4a425e9f1bb6c80f0.woff2')
       format('woff2'),
-    url('https://db.onlinewebfonts.com/t/ab0f2f4d22ea179f449ca6a60f5e599c.woff')
+    url('https://db.onlinewebfonts.com/t/000be6a5acfcd4e4a425e9f1bb6c80f0.woff')
       format('woff'),
-    url('https://db.onlinewebfonts.com/t/ab0f2f4d22ea179f449ca6a60f5e599c.ttf')
+    url('https://db.onlinewebfonts.com/t/000be6a5acfcd4e4a425e9f1bb6c80f0.ttf')
       format('truetype'),
-    url('https://db.onlinewebfonts.com/t/ab0f2f4d22ea179f449ca6a60f5e599c.svg#JYMPDD+ProductSans-Regular')
+    url('https://db.onlinewebfonts.com/t/000be6a5acfcd4e4a425e9f1bb6c80f0.svg#Google Sans Regular')
       format('svg');
   font-weight: 400;
   font-style: normal;

--- a/assets/css/resume.css
+++ b/assets/css/resume.css
@@ -1,5 +1,5 @@
 #resumePage {
-  font-family: 'JYMPDD+ProductSans-Regular', 'Poppins', sans-serif;
+  font-family: 'Google Sans Regular', 'Poppins', sans-serif;
   margin-top: 70px;
   background-color: var(--app-bg-color);
   color: var(--app-text-color);
@@ -226,7 +226,7 @@
   margin-bottom: 30px;
 }
 #resumePage .resume-section h2 {
-  font-family: 'JYMPDD+ProductSans-Regular', 'Poppins', sans-serif;
+  font-family: 'Google Sans Regular', 'Poppins', sans-serif;
   font-size: 16px;
   color: #333;
   margin-bottom: 16px;
@@ -247,7 +247,7 @@
   border-bottom-color: var(--md-sys-color-primary);
 }
 #resumePage #resume-name {
-  font-family: 'JYMPDD+ProductSans-Regular', 'Poppins', sans-serif;
+  font-family: 'Google Sans Regular', 'Poppins', sans-serif;
   font-size: 36px;
   font-weight: 700;
   color: #111;
@@ -255,7 +255,7 @@
   letter-spacing: -0.5px;
 }
 #resumePage #resume-job-title {
-  font-family: 'JYMPDD+ProductSans-Regular', 'Poppins', sans-serif;
+  font-family: 'Google Sans Regular', 'Poppins', sans-serif;
   font-size: 20px;
   color: var(--md-sys-color-secondary);
   margin-bottom: 24px;

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -74,64 +74,64 @@
   --safe-area-bottom-offset: calc(
     env(safe-area-inset-bottom, 0px) - var(--safe-area-max-inset-bottom)
   );
-  --md-sys-typescale-label-large-font-family-name: 'JYMPDD+ProductSans-Regular';
-  --md-sys-typescale-label-large-font: 'JYMPDD+ProductSans-Regular',
+  --md-sys-typescale-label-large-font-family-name: 'Google Sans Regular';
+  --md-sys-typescale-label-large-font: 'Google Sans Regular',
     'Poppins', sans-serif;
   --md-sys-typescale-label-large-weight: 500;
-  --md-sys-typescale-label-medium-font-family-name: 'JYMPDD+ProductSans-Regular';
-  --md-sys-typescale-label-medium-font: 'JYMPDD+ProductSans-Regular',
+  --md-sys-typescale-label-medium-font-family-name: 'Google Sans Regular';
+  --md-sys-typescale-label-medium-font: 'Google Sans Regular',
     'Poppins', sans-serif;
   --md-sys-typescale-label-medium-weight: 500;
-  --md-sys-typescale-label-small-font-family-name: 'JYMPDD+ProductSans-Regular';
-  --md-sys-typescale-label-small-font: 'JYMPDD+ProductSans-Regular',
+  --md-sys-typescale-label-small-font-family-name: 'Google Sans Regular';
+  --md-sys-typescale-label-small-font: 'Google Sans Regular',
     'Poppins', sans-serif;
   --md-sys-typescale-label-small-weight: 500;
-  --md-sys-typescale-body-large-font-family-name: 'JYMPDD+ProductSans-Regular';
-  --md-sys-typescale-body-large-font: 'JYMPDD+ProductSans-Regular',
+  --md-sys-typescale-body-large-font-family-name: 'Google Sans Regular';
+  --md-sys-typescale-body-large-font: 'Google Sans Regular',
     'Poppins', sans-serif;
   --md-sys-typescale-body-large-weight: 400;
-  --md-sys-typescale-body-medium-font-family-name: 'JYMPDD+ProductSans-Regular';
-  --md-sys-typescale-body-medium-font: 'JYMPDD+ProductSans-Regular',
+  --md-sys-typescale-body-medium-font-family-name: 'Google Sans Regular';
+  --md-sys-typescale-body-medium-font: 'Google Sans Regular',
     'Poppins', sans-serif;
   --md-sys-typescale-body-medium-weight: 400;
-  --md-sys-typescale-body-small-font-family-name: 'JYMPDD+ProductSans-Regular';
-  --md-sys-typescale-body-small-font: 'JYMPDD+ProductSans-Regular',
+  --md-sys-typescale-body-small-font-family-name: 'Google Sans Regular';
+  --md-sys-typescale-body-small-font: 'Google Sans Regular',
     'Poppins', sans-serif;
   --md-sys-typescale-body-small-weight: 400;
-  --md-sys-typescale-title-large-font-family-name: 'JYMPDD+ProductSans-Regular';
-  --md-sys-typescale-title-large-font: 'JYMPDD+ProductSans-Regular',
+  --md-sys-typescale-title-large-font-family-name: 'Google Sans Regular';
+  --md-sys-typescale-title-large-font: 'Google Sans Regular',
     'Poppins', sans-serif;
   --md-sys-typescale-title-large-weight: 500;
-  --md-sys-typescale-title-medium-font-family-name: 'JYMPDD+ProductSans-Regular';
-  --md-sys-typescale-title-medium-font: 'JYMPDD+ProductSans-Regular',
+  --md-sys-typescale-title-medium-font-family-name: 'Google Sans Regular';
+  --md-sys-typescale-title-medium-font: 'Google Sans Regular',
     'Poppins', sans-serif;
   --md-sys-typescale-title-medium-weight: 500;
-  --md-sys-typescale-title-small-font-family-name: 'JYMPDD+ProductSans-Regular';
-  --md-sys-typescale-title-small-font: 'JYMPDD+ProductSans-Regular',
+  --md-sys-typescale-title-small-font-family-name: 'Google Sans Regular';
+  --md-sys-typescale-title-small-font: 'Google Sans Regular',
     'Poppins', sans-serif;
   --md-sys-typescale-title-small-weight: 500;
-  --md-sys-typescale-headline-large-font-family-name: 'JYMPDD+ProductSans-Regular';
-  --md-sys-typescale-headline-large-font: 'JYMPDD+ProductSans-Regular',
+  --md-sys-typescale-headline-large-font-family-name: 'Google Sans Regular';
+  --md-sys-typescale-headline-large-font: 'Google Sans Regular',
     'Poppins', sans-serif;
   --md-sys-typescale-headline-large-weight: 500;
-  --md-sys-typescale-headline-medium-font-family-name: 'JYMPDD+ProductSans-Regular';
-  --md-sys-typescale-headline-medium-font: 'JYMPDD+ProductSans-Regular',
+  --md-sys-typescale-headline-medium-font-family-name: 'Google Sans Regular';
+  --md-sys-typescale-headline-medium-font: 'Google Sans Regular',
     'Poppins', sans-serif;
   --md-sys-typescale-headline-medium-weight: 500;
-  --md-sys-typescale-headline-small-font-family-name: 'JYMPDD+ProductSans-Regular';
-  --md-sys-typescale-headline-small-font: 'JYMPDD+ProductSans-Regular',
+  --md-sys-typescale-headline-small-font-family-name: 'Google Sans Regular';
+  --md-sys-typescale-headline-small-font: 'Google Sans Regular',
     'Poppins', sans-serif;
   --md-sys-typescale-headline-small-weight: 500;
-  --md-sys-typescale-display-large-font-family-name: 'JYMPDD+ProductSans-Regular';
-  --md-sys-typescale-display-large-font: 'JYMPDD+ProductSans-Regular',
+  --md-sys-typescale-display-large-font-family-name: 'Google Sans Regular';
+  --md-sys-typescale-display-large-font: 'Google Sans Regular',
     'Poppins', sans-serif;
   --md-sys-typescale-display-large-weight: 500;
-  --md-sys-typescale-display-medium-font-family-name: 'JYMPDD+ProductSans-Regular';
-  --md-sys-typescale-display-medium-font: 'JYMPDD+ProductSans-Regular',
+  --md-sys-typescale-display-medium-font-family-name: 'Google Sans Regular';
+  --md-sys-typescale-display-medium-font: 'Google Sans Regular',
     'Poppins', sans-serif;
   --md-sys-typescale-display-medium-weight: 500;
-  --md-sys-typescale-display-small-font-family-name: 'JYMPDD+ProductSans-Regular';
-  --md-sys-typescale-display-small-font: 'JYMPDD+ProductSans-Regular',
+  --md-sys-typescale-display-small-font-family-name: 'Google Sans Regular';
+  --md-sys-typescale-display-small-font: 'Google Sans Regular',
     'Poppins', sans-serif;
   --md-sys-typescale-display-small-weight: 500;
 }

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=privacy_tip"
     />
     <link
-      href="https://db.onlinewebfonts.com/c/ab0f2f4d22ea179f449ca6a60f5e599c?family=JYMPDD%2BProductSans-Regular"
+      href="https://db.onlinewebfonts.com/c/000be6a5acfcd4e4a425e9f1bb6c80f0?family=Google+Sans+Regular"
       rel="stylesheet"
     />
     <link


### PR DESCRIPTION
## Summary
- load the Google Sans Regular webfont instead of Product Sans
- point global typography variables and component-specific tokens to the new family
- update base and resume styles so text renders with Google Sans

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d00f129120832dbf2084a3f64f9056