### PR TITLE
Improve scroll reveal animations and fix direction detection for Smart Cleaner page

### DIFF
--- a/assets/css/pages.css
+++ b/assets/css/pages.css
@@ -1783,27 +1783,42 @@
 }
 
 #smartCleanerPageContainer .smart-cleaner-reveal {
+  --reveal-y: 32px;
+  --reveal-scale: 0.95;
+  --reveal-duration: 820ms;
+  --reveal-ease: cubic-bezier(0.16, 1, 0.3, 1);
   opacity: 0;
-  --smart-reveal-offset: 26px;
-  transform: translateY(var(--smart-reveal-offset)) scale(0.97);
-  transition: opacity 420ms ease, transform 420ms cubic-bezier(0.22, 0.61, 0.36, 1);
+  transform: translate3d(0, var(--reveal-y), 0) scale(var(--reveal-scale));
+  transform-origin: 50% 50%;
+  will-change: transform, opacity;
+  backface-visibility: hidden;
+  transition:
+    transform var(--reveal-duration) var(--reveal-ease),
+    opacity calc(var(--reveal-duration) * 0.7) var(--reveal-ease);
 }
 
 #smartCleanerPageContainer .smart-cleaner-reveal .smart-cleaner-reveal-item {
   opacity: 0;
-  transform: translateY(var(--smart-reveal-offset)) scale(0.97);
-  transition: opacity 420ms ease, transform 420ms cubic-bezier(0.22, 0.61, 0.36, 1);
-  transition-delay: var(--smart-reveal-delay, 0ms);
+  transform: translate3d(0, 14px, 0) scale(0.98);
+  transition:
+    transform 700ms cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 560ms cubic-bezier(0.16, 1, 0.3, 1);
+  transition-delay: var(--reveal-delay, 0ms);
+  will-change: transform, opacity;
 }
 
 #smartCleanerPageContainer .smart-cleaner-reveal.reveal-from-up {
-  --smart-reveal-offset: -26px;
+  transform: translate3d(0, 32px, 0) scale(0.95);
+}
+
+#smartCleanerPageContainer .smart-cleaner-reveal.reveal-from-down {
+  transform: translate3d(0, -32px, 0) scale(0.95);
 }
 
 #smartCleanerPageContainer .smart-cleaner-reveal.is-visible,
 #smartCleanerPageContainer .smart-cleaner-reveal.is-visible .smart-cleaner-reveal-item {
   opacity: 1;
-  transform: translateY(0) scale(1);
+  transform: translate3d(0, 0, 0) scale(1);
 }
 
 #smartCleanerPageContainer .smart-cleaner-reveal-child {

--- a/assets/js/smartCleanerPage.js
+++ b/assets/js/smartCleanerPage.js
@@ -12,7 +12,7 @@
 
             children.forEach((child, index) => {
                 child.classList.add('smart-cleaner-reveal-item');
-                child.style.setProperty('--smart-reveal-delay', `${(index + 1) * 100}ms`);
+                child.style.setProperty('--reveal-delay', `${index * 70}ms`);
             });
         });
     }
@@ -35,13 +35,13 @@
         let currentScrollDirection = 'down';
 
         const applyRevealDirection = (section, direction) => {
-            section.classList.toggle('reveal-from-up', direction === 'up');
-            section.classList.toggle('reveal-from-down', direction !== 'up');
+            section.classList.remove('reveal-from-up', 'reveal-from-down');
+            section.classList.add(direction === 'down' ? 'reveal-from-up' : 'reveal-from-down');
         };
 
         global.addEventListener('scroll', () => {
             const nextScrollY = global.scrollY || global.pageYOffset || previousScrollY;
-            currentScrollDirection = nextScrollY < previousScrollY ? 'up' : 'down';
+            currentScrollDirection = nextScrollY > previousScrollY ? 'down' : 'up';
             previousScrollY = nextScrollY;
         }, { passive: true });
 
@@ -49,23 +49,26 @@
             entries.forEach((entry) => {
                 if (entry.isIntersecting) {
                     applyRevealDirection(entry.target, currentScrollDirection);
-                    entry.target.classList.add('is-visible');
+                    entry.target.classList.remove('is-visible');
+                    void entry.target.offsetWidth;
+                    global.requestAnimationFrame(() => {
+                        entry.target.classList.add('is-visible');
+                    });
                     return;
                 }
 
-                const exitedAboveViewport = entry.boundingClientRect.bottom <= 0;
-                const exitedBelowViewport = entry.boundingClientRect.top >= global.innerHeight;
-                const shouldHideOnScrollDown = currentScrollDirection === 'down' && exitedAboveViewport;
-                const shouldHideOnScrollUp = currentScrollDirection === 'up' && exitedBelowViewport;
+                const rect = entry.boundingClientRect;
+                const viewportHeight = global.innerHeight || document.documentElement.clientHeight;
+                const isFarAbove = rect.bottom < viewportHeight * 0.1;
+                const isFarBelow = rect.top > viewportHeight * 0.9;
 
-                if (shouldHideOnScrollDown || shouldHideOnScrollUp) {
-                    applyRevealDirection(entry.target, shouldHideOnScrollDown ? 'up' : 'down');
+                if (isFarAbove || isFarBelow) {
                     entry.target.classList.remove('is-visible');
                 }
             });
         }, {
-            threshold: 0.08,
-            rootMargin: '0px'
+            threshold: [0, 0.15, 0.35, 0.6],
+            rootMargin: '0px 0px -12% 0px'
         });
 
         sections.forEach((section) => sectionObserver.observe(section));


### PR DESCRIPTION
### Motivation
- Make the reveal animations for the Smart Cleaner page smoother and more consistent by moving to 3D transforms, tuned easing and durations.
- Fix scroll direction detection and reveal/hide behavior so sections animate correctly when entering and exiting the viewport.
- Support restarting reveal animations reliably when elements re-enter view and consolidate delay variables for children.

### Description
- Updated CSS to use `translate3d`, `scale` and new variables `--reveal-y`, `--reveal-scale`, `--reveal-duration`, and `--reveal-ease`, added `will-change` and `backface-visibility` for smoother rendering, and adjusted transitions for parent and child reveal elements.
- Renamed child delay property from `--smart-reveal-delay` to `--reveal-delay` and changed child transform/transition timings for a staggered effect.
- Added a `.reveal-from-down` modifier and changed how `.reveal-from-up` / `.reveal-from-down` are applied by removing both and adding the appropriate class based on scroll direction.
- In `initScrollReveal` changed the scroll direction comparator to correctly determine `up` vs `down`, updated the IntersectionObserver thresholds and `rootMargin`, and implemented logic to consider elements "far" above/below the viewport before hiding them.
- Implemented an animation restart technique by removing `is-visible`, forcing reflow (`void entry.target.offsetWidth`), and then adding `is-visible` inside `requestAnimationFrame` so re-entry triggers the transition.

### Testing
- Ran linter via `npm run lint` and it completed without errors.
- Ran the test suite via `npm run test` and all tests passed.
- Built the static assets via `npm run build` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc589bec48832db28703a7affdf29d)