### PR TITLE
Refine Smart Cleaner reveal animation behavior

### DIFF
--- a/assets/css/pages.css
+++ b/assets/css/pages.css
@@ -1782,37 +1782,45 @@
   max-width: 58ch;
 }
 
+/* --- PREMIUM SCROLL REVEAL --- */
 #smartCleanerPageContainer .smart-cleaner-reveal {
-  --reveal-y: 32px;
-  --reveal-scale: 0.95;
-  --reveal-duration: 820ms;
-  --reveal-ease: cubic-bezier(0.16, 1, 0.3, 1);
+  --reveal-y: 38px;
+  --reveal-scale: 0.96;
+  --reveal-duration: 800ms;
+  --reveal-ease: cubic-bezier(0.2, 0.8, 0.2, 1);
   opacity: 0;
-  transform: translate3d(0, var(--reveal-y), 0) scale(var(--reveal-scale));
-  transform-origin: 50% 50%;
   will-change: transform, opacity;
   backface-visibility: hidden;
+  transform: translate3d(0, var(--reveal-y), 0) scale(var(--reveal-scale));
   transition:
     transform var(--reveal-duration) var(--reveal-ease),
-    opacity calc(var(--reveal-duration) * 0.7) var(--reveal-ease);
+    opacity calc(var(--reveal-duration) * 0.8) var(--reveal-ease);
+}
+
+#smartCleanerPageContainer .smart-cleaner-reveal.reveal-from-up {
+  transform: translate3d(0, var(--reveal-y), 0) scale(var(--reveal-scale));
+}
+
+#smartCleanerPageContainer .smart-cleaner-reveal.reveal-from-down {
+  transform: translate3d(0, calc(var(--reveal-y) * -1), 0) scale(var(--reveal-scale));
 }
 
 #smartCleanerPageContainer .smart-cleaner-reveal .smart-cleaner-reveal-item {
   opacity: 0;
-  transform: translate3d(0, 14px, 0) scale(0.98);
-  transition:
-    transform 700ms cubic-bezier(0.16, 1, 0.3, 1),
-    opacity 560ms cubic-bezier(0.16, 1, 0.3, 1);
-  transition-delay: var(--reveal-delay, 0ms);
   will-change: transform, opacity;
+  transform: translate3d(0, 16px, 0);
+  transition:
+    transform 700ms var(--reveal-ease),
+    opacity 560ms var(--reveal-ease);
+  transition-delay: var(--reveal-delay, 0ms);
 }
 
-#smartCleanerPageContainer .smart-cleaner-reveal.reveal-from-up {
-  transform: translate3d(0, 32px, 0) scale(0.95);
+#smartCleanerPageContainer .smart-cleaner-reveal.reveal-from-up .smart-cleaner-reveal-item {
+  transform: translate3d(0, 16px, 0);
 }
 
-#smartCleanerPageContainer .smart-cleaner-reveal.reveal-from-down {
-  transform: translate3d(0, -32px, 0) scale(0.95);
+#smartCleanerPageContainer .smart-cleaner-reveal.reveal-from-down .smart-cleaner-reveal-item {
+  transform: translate3d(0, -16px, 0);
 }
 
 #smartCleanerPageContainer .smart-cleaner-reveal.is-visible,

--- a/assets/js/smartCleanerPage.js
+++ b/assets/js/smartCleanerPage.js
@@ -47,12 +47,29 @@
 
         const sectionObserver = new global.IntersectionObserver((entries) => {
             entries.forEach((entry) => {
+                const el = entry.target;
+
                 if (entry.isIntersecting) {
-                    applyRevealDirection(entry.target, currentScrollDirection);
-                    entry.target.classList.remove('is-visible');
-                    void entry.target.offsetWidth;
+                    if (el.classList.contains('is-visible')) {
+                        return;
+                    }
+
+                    const items = el.querySelectorAll('.smart-cleaner-reveal-item');
+                    el.style.transition = 'none';
+                    items.forEach((item) => {
+                        item.style.transition = 'none';
+                    });
+
+                    applyRevealDirection(el, currentScrollDirection);
+                    void el.offsetWidth;
+
+                    el.style.transition = '';
+                    items.forEach((item) => {
+                        item.style.transition = '';
+                    });
+
                     global.requestAnimationFrame(() => {
-                        entry.target.classList.add('is-visible');
+                        el.classList.add('is-visible');
                     });
                     return;
                 }
@@ -63,12 +80,12 @@
                 const isFarBelow = rect.top > viewportHeight * 0.9;
 
                 if (isFarAbove || isFarBelow) {
-                    entry.target.classList.remove('is-visible');
+                    el.classList.remove('is-visible');
                 }
             });
         }, {
             threshold: [0, 0.15, 0.35, 0.6],
-            rootMargin: '0px 0px -12% 0px'
+            rootMargin: '0px 0px -10% 0px'
         });
 
         sections.forEach((section) => sectionObserver.observe(section));


### PR DESCRIPTION
### Motivation
- Fix a visual jitter on reverse scroll and ensure reveal child elements animate in the same direction as their parent so the Smart Cleaner page feels smooth and studio-grade.

### Description
- Updated `initScrollReveal` in `assets/js/smartCleanerPage.js` to implement the transition-kill pattern: temporarily disable transitions on the section and its `.smart-cleaner-reveal-item` children, apply the directional class, force layout (`void el.offsetWidth`), re-enable transitions, then add `is-visible` on the next animation frame, and guard against re-triggering when already visible.
- Tuned observer behavior by changing the `rootMargin` to `"0px 0px -10% 0px"` and preserved the existing far-above / far-below reset logic so reveals reset only when out of view.
- Replaced the `.smart-cleaner-reveal` rules in `assets/css/pages.css` with the premium reveal block that updates variables (`--reveal-y: 38px`, `--reveal-scale: 0.96`, `--reveal-duration: 800ms`, `--reveal-ease: cubic-bezier(0.2, 0.8, 0.2, 1)`), ensures children use `var(--reveal-ease)`, and adds directional transforms so children slide in the same direction as their parent.

### Testing
- Inspected and located the relevant blocks with `rg`/`sed` and reviewed the applied diff with `git diff` to verify the JS and CSS changes target the expected lines and selectors.
- Applied the patch to `assets/js/smartCleanerPage.js` and `assets/css/pages.css` and validated the updated files are present in the working tree via `git status --short`.
- No automated browser or visual regression tests were available in this execution environment, so runtime visual verification in a browser was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc619b45a8832da0817acdc8e8cd65)