### PR TITLE
Rework songs page to load D4rK Rekords tracks from Songlink / Odesli API

### DIFF
--- a/__tests__/songs.test.js
+++ b/__tests__/songs.test.js
@@ -14,7 +14,7 @@ describe('songs module', () => {
         delete global.fetch;
     });
 
-    test('fetchChannelVideos throws an error with response message when request fails', async () => {
+    test('fetchArtistSongs throws an error with response message when request fails', async () => {
         const errorText = 'Something went wrong';
         const mockText = jest.fn().mockResolvedValue(errorText);
         const response = {
@@ -25,9 +25,9 @@ describe('songs module', () => {
 
         global.fetch.mockResolvedValue(response);
 
-        const { fetchChannelVideos } = require('../assets/js/songs.js');
+        const { fetchArtistSongs } = require('../assets/js/songs.js');
 
-        await expect(fetchChannelVideos('channel123')).rejects.toThrow(
+        await expect(fetchArtistSongs('artist123')).rejects.toThrow(
             `HTTP error! status: 502, message: ${errorText}`
         );
         expect(mockText).toHaveBeenCalledTimes(1);
@@ -35,18 +35,18 @@ describe('songs module', () => {
 
     test('loadSongs renders fetched tracks, applies fallback image, and hides status indicator', async () => {
         const mockJson = jest.fn().mockResolvedValue({
-            relatedStreams: [
+            songs: [
                 {
-                    title: 'First Song',
-                    uploaderName: 'First Artist',
+                    song_name: 'First Song',
+                    artist_name: 'First Artist',
                     thumbnail: 'https://cdn.example.com/thumb1.jpg',
-                    url: '/watch?v=first'
+                    universal_link: 'https://song.link/first'
                 },
                 {
                     title: 'Second Song',
-                    uploaderName: 'Second Artist',
-                    thumbnail: null,
-                    url: '/watch?v=second'
+                    artists: 'Second Artist',
+                    image: null,
+                    link: 'https://song.link/second'
                 }
             ]
         });
@@ -74,7 +74,7 @@ describe('songs module', () => {
         expect(firstImg.alt).toBe('First Song');
         expect(firstCard.querySelector('h3').textContent).toBe('First Song');
         expect(firstCard.querySelector('p').textContent).toBe('First Artist');
-        expect(firstCard.querySelector('a').href).toBe('https://www.youtube.com/watch?v=first');
+        expect(firstCard.querySelector('a').href).toBe('https://song.link/first');
 
         const secondImg = secondCard.querySelector('img');
         expect(secondImg.src).toContain(PLACEHOLDER_SRC);

--- a/assets/js/songs.js
+++ b/assets/js/songs.js
@@ -1,42 +1,59 @@
-"use strict";
 // @ts-nocheck
-const youtubeChannelId = 'UCtzlWsxUK8FSvLwLDbESw4A';
-async function fetchChannelVideos(channelId) {
-    const url = `https://pipedapi.ducks.party/channel/${channelId}`;
+
+const ODESLI_API_BASE_URL = 'https://publicapi.dev/songlink';
+const D4RK_REKORDS_ARTIST_ID = 'd4rk-rekords';
+
+function mapTrack(rawTrack) {
+    return {
+        title: rawTrack?.title || rawTrack?.song_name || 'Unknown title',
+        artists: rawTrack?.artists || rawTrack?.artist_name || 'D4rK Rekords',
+        image: rawTrack?.image || rawTrack?.thumbnail || rawTrack?.artwork || null,
+        link: rawTrack?.link || rawTrack?.universal_link || rawTrack?.url || '#'
+    };
+}
+
+async function fetchArtistSongs(artistId) {
+    const url = `${ODESLI_API_BASE_URL}/api/odesli/${encodeURIComponent(artistId)}`;
     const resp = await fetch(url);
+
     if (!resp.ok) {
         const errorText = await resp.text();
         throw new Error(`HTTP error! status: ${resp.status}, message: ${errorText}`);
     }
+
     const data = await resp.json();
-    const streams = data.relatedStreams || [];
-    return streams.map(v => ({
-        title: v.title,
-        artists: v.uploaderName,
-        image: v.thumbnail,
-        link: `https://www.youtube.com${v.url}`
-    }));
+    const songs = Array.isArray(data?.songs)
+        ? data.songs
+        : Array.isArray(data?.tracks)
+            ? data.tracks
+            : Array.isArray(data)
+                ? data
+                : [];
+
+    return songs.map(mapTrack);
 }
+
 async function loadSongs() {
     const grid = document.getElementById('songsGrid');
     const status = document.getElementById('songs-status');
-    if (!grid)
-        return;
-    if (status)
-        status.style.display = 'flex';
+    if (!grid) return;
+
+    if (status) status.style.display = 'flex';
     grid.innerHTML = '';
+
     let tracks = [];
     try {
-        tracks = await fetchChannelVideos(youtubeChannelId);
+        tracks = await fetchArtistSongs(D4RK_REKORDS_ARTIST_ID);
+    } catch (err) {
+        console.error('Failed to fetch songs list from Songlink / Odesli API', err);
     }
-    catch (err) {
-        console.error('Failed to fetch songs list', err);
-    }
+
     for (const track of tracks) {
         const img = track.image || 'assets/images/placeholder.png';
         const title = track.title;
         const artists = track.artists;
         const link = track.link;
+
         const card = document.createElement('div');
         card.className = 'song-card';
         card.innerHTML = `
@@ -44,30 +61,31 @@ async function loadSongs() {
             <div class="song-card-content">
                 <h3>${title}</h3>
                 <p>${artists}</p>
-                <div class="song-card-links"><a href="${link}" target="_blank" rel="noopener noreferrer">YouTube</a></div>
+                <div class="song-card-links"><a href="${link}" target="_blank" rel="noopener noreferrer">Open Song</a></div>
             </div>`;
         grid.appendChild(card);
     }
+
     if (typeof SiteAnimations !== 'undefined' && SiteAnimations && typeof SiteAnimations.animateSongCards === 'function') {
         try {
             SiteAnimations.animateSongCards(grid.querySelectorAll('.song-card'));
-        }
-        catch (animationError) {
+        } catch (animationError) {
             console.error('Songs: Failed to animate song cards.', animationError);
         }
     }
-    if (status)
-        status.style.display = 'none';
+
+    if (status) status.style.display = 'none';
 }
-// When router loads the page dynamically
+
 document.addEventListener('DOMContentLoaded', () => {
     if (document.getElementById('songsGrid')) {
         loadSongs();
     }
 });
+
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
-        fetchChannelVideos,
+        fetchArtistSongs,
         loadSongs
     };
 }

--- a/assets/ts/songs.ts
+++ b/assets/ts/songs.ts
@@ -1,35 +1,53 @@
 // @ts-nocheck
 
-const youtubeChannelId = 'UCtzlWsxUK8FSvLwLDbESw4A';
-async function fetchChannelVideos(channelId) {
-    const url = `https://pipedapi.ducks.party/channel/${channelId}`;
+const ODESLI_API_BASE_URL = 'https://publicapi.dev/songlink';
+const D4RK_REKORDS_ARTIST_ID = 'd4rk-rekords';
+
+function mapTrack(rawTrack) {
+    return {
+        title: rawTrack?.title || rawTrack?.song_name || 'Unknown title',
+        artists: rawTrack?.artists || rawTrack?.artist_name || 'D4rK Rekords',
+        image: rawTrack?.image || rawTrack?.thumbnail || rawTrack?.artwork || null,
+        link: rawTrack?.link || rawTrack?.universal_link || rawTrack?.url || '#'
+    };
+}
+
+async function fetchArtistSongs(artistId) {
+    const url = `${ODESLI_API_BASE_URL}/api/odesli/${encodeURIComponent(artistId)}`;
     const resp = await fetch(url);
+
     if (!resp.ok) {
         const errorText = await resp.text();
         throw new Error(`HTTP error! status: ${resp.status}, message: ${errorText}`);
     }
+
     const data = await resp.json();
-    const streams = data.relatedStreams || [];
-    return streams.map(v => ({
-        title: v.title,
-        artists: v.uploaderName,
-        image: v.thumbnail,
-        link: `https://www.youtube.com${v.url}`
-    }));
+    const songs = Array.isArray(data?.songs)
+        ? data.songs
+        : Array.isArray(data?.tracks)
+            ? data.tracks
+            : Array.isArray(data)
+                ? data
+                : [];
+
+    return songs.map(mapTrack);
 }
 
 async function loadSongs() {
     const grid = document.getElementById('songsGrid');
     const status = document.getElementById('songs-status');
     if (!grid) return;
+
     if (status) status.style.display = 'flex';
     grid.innerHTML = '';
+
     let tracks = [];
     try {
-        tracks = await fetchChannelVideos(youtubeChannelId);
+        tracks = await fetchArtistSongs(D4RK_REKORDS_ARTIST_ID);
     } catch (err) {
-        console.error('Failed to fetch songs list', err);
+        console.error('Failed to fetch songs list from Songlink / Odesli API', err);
     }
+
     for (const track of tracks) {
         const img = track.image || 'assets/images/placeholder.png';
         const title = track.title;
@@ -43,7 +61,7 @@ async function loadSongs() {
             <div class="song-card-content">
                 <h3>${title}</h3>
                 <p>${artists}</p>
-                <div class="song-card-links"><a href="${link}" target="_blank" rel="noopener noreferrer">YouTube</a></div>
+                <div class="song-card-links"><a href="${link}" target="_blank" rel="noopener noreferrer">Open Song</a></div>
             </div>`;
         grid.appendChild(card);
     }
@@ -55,10 +73,10 @@ async function loadSongs() {
             console.error('Songs: Failed to animate song cards.', animationError);
         }
     }
+
     if (status) status.style.display = 'none';
 }
 
-// When router loads the page dynamically
 document.addEventListener('DOMContentLoaded', () => {
     if (document.getElementById('songsGrid')) {
         loadSongs();
@@ -67,7 +85,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
-        fetchChannelVideos,
+        fetchArtistSongs,
         loadSongs
     };
 }

--- a/pages/drawer/songs.html
+++ b/pages/drawer/songs.html
@@ -3,7 +3,7 @@
   <div class="songs-grid" id="songsGrid">
     <div id="songs-status">
       <md-circular-progress indeterminate></md-circular-progress>
-      <span>Loading songs...</span>
+      <span>Loading songs from D4rK Rekords...</span>
     </div>
   </div>
 </div>


### PR DESCRIPTION
### Motivation
- Replace the previous YouTube-channel based song list with a platform-agnostic universal-link source for D4rK Rekords so the site can surface links across streaming platforms.
- Make the songs fetch resilient to varied API payload shapes and field names returned by Songlink/Odesli endpoints.

### Description
- Replaced the old Piped/YouTube fetch with a new `fetchArtistSongs` flow that calls `https://publicapi.dev/songlink/api/odesli/{artistId}` and errors with the HTTP response message on failure.
- Added a `mapTrack` normalization function to unify fields like `song_name`/`title`, `artist_name`/`artists`, `thumbnail`/`image` and pick `universal_link`/`link` for each track.
- Updated rendering to use the normalized track model, changed the CTA text to `Open Song`, and preserved the placeholder image fallback and animation invocation.
- Updated the loading copy in `pages/drawer/songs.html` and replaced `assets/js/songs.js` and `assets/ts/songs.ts` implementations; tests were updated in `__tests__/songs.test.js` to cover the new function and payload shapes.

### Testing
- Ran `npm test -- songs.test.js`, which executed the updated suite for the songs module and passed (2 tests, 1 suite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1823f8e980832daada6fc14815e3af)