### PR TITLE
Restructure tests to mirror source layout

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,7 +79,7 @@ This keeps `src/features/**/presentation/*.html` as reviewed source while keepin
 3. Add any feature behavior under `src/features/<feature>/...`, using `data/`, `domain`, and `presentation/` according to responsibility.
 4. Register the route in `src/app/router/RouteRegistry.ts`, keeping the public hash route ID stable and pointing `path` at the generated `content/features/<feature>/presentation/<page>.html` copy.
 5. Add any shared helper only if at least two features need it.
-6. Add or update tests under `__tests__/`, importing TypeScript from `src/` instead of generated `dist/assets/js/`.
+6. Add or update tests under `tests/`, mirroring `src/` where practical and importing TypeScript from `src/` instead of generated `dist/assets/js/`.
 7. Run `npm test -- --runInBand` and `npm run build` as appropriate for the change.
 
 ## Static assets

--- a/robots.txt
+++ b/robots.txt
@@ -1,6 +1,6 @@
 User-agent: *
 Allow: /
-Disallow: /__tests__/
+Disallow: /tests/
 Disallow: /node_modules/
 
 Sitemap: https://mihaicristiancondrea.github.io/profile/sitemap.xml

--- a/tests/app/App.test.ts
+++ b/tests/app/App.test.ts
@@ -1,4 +1,4 @@
-const APP_PATH = '../src/app/App';
+const APP_PATH = '../../src/app/App';
 
 const OPTIONAL_GLOBALS = [
   'showPageLoadingOverlay',

--- a/tests/app/router/Router.test.ts
+++ b/tests/app/router/Router.test.ts
@@ -1,6 +1,6 @@
 // codex/add-tests-for-router.js-with-jsdom (resolved)
 
-const { readTranspiledSource } = require('../test-utils/sourceLoader');
+const { readTranspiledSource } = require('../../utils/sourceLoader');
 const vm = require('vm');
 const { TextEncoder, TextDecoder } = require('util');
 global.TextEncoder = TextEncoder;
@@ -366,8 +366,8 @@ describe('loadPageContent behavior', () => {
 
 /* ===== Additional module-level tests (from other branch) ===== */
 
-const ROUTES_PATH = '../src/app/router/RouteRegistry';
-const CONTENT_LOADER_PATH = '../src/app/router/ContentLoader';
+const ROUTES_PATH = '../../../src/app/router/RouteRegistry';
+const CONTENT_LOADER_PATH = '../../../src/app/router/ContentLoader';
 
 const originalGlobalFetch = global.fetch;
 const originalWindowFetch = typeof window !== 'undefined' ? window.fetch : undefined;

--- a/tests/app/router/RouterHelpers.test.ts
+++ b/tests/app/router/RouterHelpers.test.ts
@@ -1,5 +1,5 @@
-const animationScriptPath = '../src/app/router/RouteAnimation';
-const historyScriptPath = '../src/app/router/HistoryManager';
+const animationScriptPath = '../../../src/app/router/RouteAnimation';
+const historyScriptPath = '../../../src/app/router/HistoryManager';
 
 function loadHelpers() {
   require(animationScriptPath);

--- a/tests/core/dom/DomUtils.test.ts
+++ b/tests/core/dom/DomUtils.test.ts
@@ -4,7 +4,7 @@ const {
   getDynamicElement,
   showPageLoadingOverlay,
   hidePageLoadingOverlay
-} = require('../src/core/dom/DomUtils');
+} = require('../../../src/core/dom/DomUtils');
 
 describe('getNestedValue', () => {
   test('retrieves nested values with dot notation', () => {

--- a/tests/core/metadata/MetadataManager.test.ts
+++ b/tests/core/metadata/MetadataManager.test.ts
@@ -1,5 +1,5 @@
 describe('SiteMetadata.updateForRoute', () => {
-  const modulePath = '../src/core/metadata/MetadataManager';
+  const modulePath = '../../../src/core/metadata/MetadataManager';
 
   beforeEach(() => {
     jest.resetModules();

--- a/tests/core/theme/ThemeManager.test.ts
+++ b/tests/core/theme/ThemeManager.test.ts
@@ -1,4 +1,4 @@
-const { readTranspiledSource } = require('../test-utils/sourceLoader');
+const { readTranspiledSource } = require('../../utils/sourceLoader');
 const vm = require('vm');
 
 const themeSource = readTranspiledSource('src/core/theme/ThemeManager.ts');

--- a/tests/features/apps/smart-cleaner/presentation/SmartCleanerPage.test.ts
+++ b/tests/features/apps/smart-cleaner/presentation/SmartCleanerPage.test.ts
@@ -1,4 +1,4 @@
-const SMART_CLEANER_PAGE_SCRIPT = '../src/features/apps/smart-cleaner/presentation/SmartCleanerPage';
+const SMART_CLEANER_PAGE_SCRIPT = '../../../../../src/features/apps/smart-cleaner/presentation/SmartCleanerPage';
 
 function loadScript() {
   jest.isolateModules(() => {

--- a/tests/features/blog/data/BloggerApiClient.test.ts
+++ b/tests/features/blog/data/BloggerApiClient.test.ts
@@ -1,9 +1,9 @@
-const { readTranspiledSource } = require('../test-utils/sourceLoader');
+const { readTranspiledSource } = require('../../../utils/sourceLoader');
 
 const {
   getNestedValue,
   extractFirstImageFromHtml
-} = require('../src/core/dom/DomUtils');
+} = require('../../../../src/core/dom/DomUtils');
 
 const dataScriptContent = readTranspiledSource('src/features/blog/data/BloggerApiClient.ts');
 const presentationScriptContent = readTranspiledSource('src/features/blog/presentation/BlogPosts.ts');

--- a/tests/features/navigation-drawer/presentation/NavigationDrawer.test.ts
+++ b/tests/features/navigation-drawer/presentation/NavigationDrawer.test.ts
@@ -1,4 +1,4 @@
-const { readTranspiledSource } = require('../test-utils/sourceLoader');
+const { readTranspiledSource } = require('../../../utils/sourceLoader');
 
 describe('NavigationDrawer integration', () => {
   const scriptContent = readTranspiledSource('src/features/navigation-drawer/presentation/NavigationDrawer.ts');

--- a/tests/features/projects/presentation/ProjectsPage.test.ts
+++ b/tests/features/projects/presentation/ProjectsPage.test.ts
@@ -14,7 +14,7 @@ describe('ensureProjectsMarkedLoaded', () => {
       return node;
     });
 
-    const { ensureProjectsMarkedLoaded } = require('../src/features/projects/presentation/ProjectsPage');
+    const { ensureProjectsMarkedLoaded } = require('../../../../src/features/projects/presentation/ProjectsPage');
 
     const firstCall = ensureProjectsMarkedLoaded();
     expect(appendSpy).toHaveBeenCalledTimes(1);
@@ -85,7 +85,7 @@ describe('initProjectsPage interactions', () => {
       return { finished };
     });
 
-    const { initProjectsPage } = require('../src/features/projects/presentation/ProjectsPage');
+    const { initProjectsPage } = require('../../../../src/features/projects/presentation/ProjectsPage');
     await initProjectsPage();
 
     const markdownElement = document.querySelector('[data-md]');

--- a/tests/features/resume/data/CommittersDataSource.test.ts
+++ b/tests/features/resume/data/CommittersDataSource.test.ts
@@ -2,7 +2,7 @@ describe('CommittersDataSource helpers', () => {
   beforeAll(() => {
     jest.resetModules();
     // Load the TypeScript source so it attaches helpers to the JSDOM window.
-    require('../src/features/resume/data/CommittersDataSource');
+    require('../../../../src/features/resume/data/CommittersDataSource');
   });
 
   afterEach(() => {

--- a/tests/features/resume/presentation/ResumePage.test.ts
+++ b/tests/features/resume/presentation/ResumePage.test.ts
@@ -1,4 +1,4 @@
-const { readTranspiledSource } = require('../test-utils/sourceLoader');
+const { readTranspiledSource } = require('../../../utils/sourceLoader');
 
 const resumeScript = readTranspiledSource('src/features/resume/presentation/ResumePage.ts');
 

--- a/tests/features/songs/presentation/SongsPage.test.ts
+++ b/tests/features/songs/presentation/SongsPage.test.ts
@@ -1,7 +1,7 @@
 const PLACEHOLDER_SRC = 'images/placeholder.png';
-const SONG_DATA_SCRIPT = '../src/features/songs/data/SongApiClient';
-const SONG_DOMAIN_SCRIPT = '../src/features/songs/domain/SongMapper';
-const SONG_PRESENTATION_SCRIPT = '../src/features/songs/presentation/SongsPage';
+const SONG_DATA_SCRIPT = '../../../../src/features/songs/data/SongApiClient';
+const SONG_DOMAIN_SCRIPT = '../../../../src/features/songs/domain/SongMapper';
+const SONG_PRESENTATION_SCRIPT = '../../../../src/features/songs/presentation/SongsPage';
 
 function loadSongsModule() {
     require(SONG_DATA_SCRIPT);

--- a/tests/utils/sourceLoader.ts
+++ b/tests/utils/sourceLoader.ts
@@ -3,7 +3,7 @@ const path = require('path');
 const ts = require('typescript');
 
 function readTranspiledSource(relativePath) {
-  const sourcePath = path.resolve(__dirname, '..', relativePath);
+  const sourcePath = path.resolve(__dirname, '..', '..', relativePath);
   const source = fs.readFileSync(sourcePath, 'utf8');
   return ts.transpileModule(source, {
     compilerOptions: {

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -9,6 +9,6 @@
   },
   "include": [
     "src/**/*.ts",
-    "__tests__/**/*.ts"
+    "tests/**/*.ts"
   ]
 }


### PR DESCRIPTION
### Motivation
- Align the test layout with the `src/` ownership model so tests live alongside the logical areas they exercise and mirror repository structure.
- Simplify test imports and the helper loader by placing testing utilities under `tests/utils` and adjusting path resolution for clarity and maintainability.
- Update repository documentation and robots rules to reflect the new `tests/` location so CI and contributors follow the new convention.

### Description
- Move Jest specs from the flat `__tests__/` directory into `tests/app`, `tests/core`, and `tests/features` paths that mirror `src/` ownership and update all relative `require` paths accordingly.
- Move the `sourceLoader` helper into `tests/utils/sourceLoader.ts` and update it to resolve repo-root source paths from its new location.
- Update `tsconfig.test.json` to include `tests/**/*.ts` instead of `__tests__/**/*.ts` so TypeScript-aware Jest transforms pick up the new layout.
- Update `docs/architecture.md` to recommend `tests/` and modify `robots.txt` to disallow `/tests/` instead of the removed `/__tests__/` path.

### Testing
- Ran `npm test -- --runInBand` and all test suites passed: 13 test suites, 70 tests passed.
- Ran `npm run build` which completed successfully, including the Vite build, `tsc` transpilation, and page fragment copy (`scripts/copy-page-fragments.mjs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c5851cf8c832d9a4e3d189b99fa01)